### PR TITLE
Add ntfs special file support, closes #9

### DIFF
--- a/WinDirStat/windirstat/PageGeneral.cpp
+++ b/WinDirStat/windirstat/PageGeneral.cpp
@@ -60,6 +60,7 @@ BOOL CPageGeneral::OnInitDialog( ) {
 	}
 
 void CPageGeneral::OnOK( ) {
+	TRACE( _T( "User clicked OK...\r\n" ) );
 	VERIFY( CWnd::UpdateData( ) );
 	ASSERT( m_appptr != NULL );
 	const auto Options = GetOptions( );

--- a/WinDirStat/windirstat/ScopeGuard.cpp
+++ b/WinDirStat/windirstat/ScopeGuard.cpp
@@ -9,9 +9,8 @@
 WDS_FILE_INCLUDE_MESSAGE
 
 //intentionally NOT defined as part of ScopeGuard, to reduce code duplication. //Also, produces cleaner `TRACE` output.
-#ifdef DEBUG
-void trace_out( _In_z_ PCSTR const func_expr, _In_z_ PCSTR const file_name, _In_z_ PCSTR const func_name, _In_ _In_range_( 0, INT_MAX ) const int line_number ) {
 #ifdef WDS_SCOPE_GUARD_DEBUGGING
+void trace_out( _In_z_ PCSTR const func_expr, _In_z_ PCSTR const file_name, _In_z_ PCSTR const func_name, _In_ _In_range_( 0, INT_MAX ) const int line_number ) {
 	TRACE( L"Scope guard triggered!"
 			L"\r\n\t\tScope guard initialized in file: `%S`,"
 			L"\r\n\t\tfunction:                        `%S`,"
@@ -19,12 +18,6 @@ void trace_out( _In_z_ PCSTR const func_expr, _In_z_ PCSTR const file_name, _In_
 			L"\r\n\t\tActual expression:"
 			L"\r\n%S\r\n",
 			file_name, func_name, line_number, func_expr );
-#else
-	UNREFERENCED_PARAMETER( file_name );
-	UNREFERENCED_PARAMETER( func_name );
-	UNREFERENCED_PARAMETER( line_number );
-	UNREFERENCED_PARAMETER( func_expr );
-#endif
 	}
 #endif
 

--- a/WinDirStat/windirstat/ScopeGuard.h
+++ b/WinDirStat/windirstat/ScopeGuard.h
@@ -60,18 +60,22 @@ class ScopeGuard final {
 		UNREFERENCED_PARAMETER( file_name_in );
 		UNREFERENCED_PARAMETER( func_name_in );
 		UNREFERENCED_PARAMETER( line_number_in );
+#else
+		ASSERT( line_number >= 0 );
 #endif
 		}
 
 	__forceinline
 	~ScopeGuard( ) {
-		if ( active_ ) {
-	#ifdef DEBUG
-			trace_out( func_expr, file_name, func_name, line_number );
-	#endif
-#pragma warning( suppress: 4711 )//C4711: function 'void __cdecl <lambda_[...]>::operator()(void)const __ptr64' selected for automatic inline expansion
-			function_to_call_on_scope_exit( );
+		if ( !active_ ) {
+			return;
 			}
+#ifdef WDS_SCOPE_GUARD_DEBUGGING
+		trace_out( func_expr, file_name, func_name, line_number );
+#endif
+
+#pragma warning( suppress: 4711 )//C4711: function 'void __cdecl <lambda_[...]>::operator()(void)const __ptr64' selected for automatic inline expansion
+		function_to_call_on_scope_exit( );
 		}
 
 	//intentionally ASKING for inlining.

--- a/WinDirStat/windirstat/TreeListControl.cpp
+++ b/WinDirStat/windirstat/TreeListControl.cpp
@@ -1486,8 +1486,8 @@ BOOL CTreeListControl::CreateEx( _In_ const DWORD dwExStyle, _In_ DWORD dwStyle,
 _Must_inspect_result_ _Success_( return != NULL ) _Ret_maybenull_
 CTreeListItem* CTreeListControl::GetItem( _In_ _In_range_( 0, INT_MAX ) const int i ) const {
 	ASSERT( i >= 0 );
-#ifdef DEBUG
 	const auto itemCount = CListCtrl::GetItemCount( );
+#ifdef DEBUG
 	ASSERT( i < itemCount );
 #endif
 	if ( i < itemCount ) {
@@ -1824,8 +1824,8 @@ void CTreeListControl::ExpandItemInsertChildren( _In_ const CTreeListItem* const
 
 #ifdef DEBUG
 	//Hmm. The LVM_GETSTRINGWIDTH is very poorly documented, doesn't tell us the actual width.
-	const auto stringWidth = CListCtrl::GetStringWidth( item->m_name ) + 10;
-	ASSERT( ( maxwidth == stringWidth ) || ( maxwidth == ( stringWidth - 1 ) ) || ( maxwidth == ( stringWidth + 1 ) ) );
+	//const auto stringWidth = CListCtrl::GetStringWidth( item->m_name ) + 10;
+	//ASSERT( ( maxwidth == stringWidth ) || ( maxwidth == ( stringWidth - 1 ) ) || ( maxwidth == ( stringWidth + 1 ) ) );
 #endif
 
 	if ( item->m_child_info.m_child_info_ptr == nullptr ) {

--- a/WinDirStat/windirstat/TreeListControl.cpp
+++ b/WinDirStat/windirstat/TreeListControl.cpp
@@ -1095,6 +1095,7 @@ void CTreeListControl::expand_item_no_scroll_then_doWhateverJDoes( _In_ const CT
 	}
 
 void CTreeListControl::expand_item_then_scroll_to_it( _In_ const CTreeListItem* const pathZero, _In_range_( 0, INT_MAX ) const int index, _In_ const bool showWholePath ) {
+	CWnd::SetRedraw( FALSE );
 	expand_item_no_scroll_then_doWhateverJDoes( pathZero, index );
 	ASSERT( index >= 0 );
 	const auto item_at_index = GetItem( index );
@@ -1107,6 +1108,7 @@ void CTreeListControl::expand_item_then_scroll_to_it( _In_ const CTreeListItem* 
 		VERIFY( CListCtrl::EnsureVisible( 0, false ) );
 		}
 	SelectItem( index );
+	CWnd::SetRedraw( TRUE );
 	}
 
 INT CTreeListControl::find_item_then_show_first_try_failed( _In_ const CTreeListItem* const path, _In_ const int i ) {
@@ -1725,6 +1727,7 @@ _Success_( return == true ) bool CTreeListControl::CollapseItem( _In_ _In_range_
 	bool selectNode = false;
 	const auto item_number_to_delete = ( i + 1 );
 	const auto todelete = countItemsToDelete( item, selectNode, i );
+	CWnd::SetRedraw( FALSE );
 	for ( INT m = 0; m < todelete; m++ ) {
 		
 #ifdef DEBUG
@@ -1741,6 +1744,8 @@ _Success_( return == true ) bool CTreeListControl::CollapseItem( _In_ _In_range_
 #endif
 		DeleteItem( item_number_to_delete );
 		}
+	CWnd::SetRedraw( TRUE );
+
 	item->SetExpanded( false );
 	if ( selectNode ) {
 		SelectItem( i );
@@ -1886,8 +1891,10 @@ void CTreeListControl::ExpandItem( _In_ _In_range_( 0, INT_MAX ) const int i, _I
 #endif
 
 	item->SortChildren( this );
-
+	
+	CWnd::SetRedraw( FALSE );
 	ExpandItemInsertChildren( item, i, scroll );
+	CWnd::SetRedraw( TRUE );
 
 	item->SetExpanded( true );
 

--- a/WinDirStat/windirstat/TreeListControl.cpp
+++ b/WinDirStat/windirstat/TreeListControl.cpp
@@ -1548,6 +1548,12 @@ RECT CTreeListControl::DrawNode_Indented( _In_ const CTreeListItem* const item, 
 		std::terminate( );
 		abort( );
 		}
+	auto guard = WDS_SCOPEGUARD_INSTANCE( [&] { 
+		const BOOL deleted = ::DeleteDC( hMemoryDeviceContext );
+		if ( deleted == 0 ) {
+			std::terminate( );
+			}
+		} );
 
 	
 	CSelectObject sonodes( hMemoryDeviceContext, ( IsItemStripeColor( item ) ? m_bmNodes1.m_hObject : m_bmNodes0.m_hObject ) );
@@ -1564,12 +1570,6 @@ RECT CTreeListControl::DrawNode_Indented( _In_ const CTreeListItem* const item, 
 	rcPlusMinus.bottom  = rcPlusMinus.top  + HOTNODE_CY;
 			
 	rcRest.left += NODE_WIDTH;
-	const BOOL deleted = ::DeleteDC( hMemoryDeviceContext );
-	if ( deleted == 0 ) {
-		std::terminate( );
-		abort( );
-		}
-
 	rc.right = rcRest.left;
 	return rcPlusMinus;
 	}

--- a/WinDirStat/windirstat/TreeListControl.cpp
+++ b/WinDirStat/windirstat/TreeListControl.cpp
@@ -395,8 +395,8 @@ PCWSTR const CTreeListItem::CStyle_GetExtensionStrPtr( ) const {
 	}
 
 
-std::vector<CTreeListItem*> CTreeListItem::size_sorted_vector_of_children( ) const {
-	std::vector<CTreeListItem*> children;
+std::vector<const CTreeListItem*> CTreeListItem::size_sorted_vector_of_children( ) const {
+	std::vector<const CTreeListItem*> children;
 	if ( m_child_info.m_child_info_ptr == nullptr ) {
 		//ASSERT( m_childCount == 0 );
 		ASSERT( m_child_info.m_child_info_ptr == nullptr );
@@ -466,7 +466,7 @@ std::uint64_t CTreeListItem::size_recurse( ) const {
 //	}
 
 _Success_( return != NULL ) _Must_inspect_result_ _Ret_maybenull_
-CTreeListItem* CTreeListItem::GetSortedChild( _In_ const size_t i ) const {
+const CTreeListItem* CTreeListItem::GetSortedChild( _In_ const size_t i ) const {
 	ASSERT( m_vi != nullptr );
 	ASSERT( !( m_vi->cache_sortedChildren.empty( ) ) );
 	if ( m_vi != nullptr ) {
@@ -1780,7 +1780,7 @@ void CTreeListControl::insertItemsAdjustWidths( _In_ const CTreeListItem* const 
 	//Not vectorized: 1304, loop includes assignments of different sizes
 	for ( size_t c = 0; c < count; c++ ) {
 		//ASSERT( count == item->m_childCount );
-		const auto child = item->GetSortedChild( c );//m_vi->cache_sortedChildren[i];
+		const CTreeListItem* const child = item->GetSortedChild( c );//m_vi->cache_sortedChildren[i];
 		ASSERT( child != NULL );
 		if ( child != NULL ) {
 			InsertItem( child, i + static_cast<INT_PTR>( 1 ) + static_cast<INT_PTR>( c ) );
@@ -1920,7 +1920,7 @@ void CTreeListControl::handle_VK_RIGHT( _In_ const CTreeListItem* const item, _I
 		}
 	else if ( item->m_child_info.m_child_info_ptr != nullptr ) {
 
-		const auto sortedItemAtZero = item->GetSortedChild( 0 );
+		const CTreeListItem* const sortedItemAtZero = item->GetSortedChild( 0 );
 		if ( sortedItemAtZero != NULL ){
 			SelectItem( sortedItemAtZero );
 			}

--- a/WinDirStat/windirstat/TreeListControl.cpp
+++ b/WinDirStat/windirstat/TreeListControl.cpp
@@ -1791,7 +1791,11 @@ void CTreeListControl::ExpandItemInsertChildren( _In_ const CTreeListItem* const
 	//static_assert( COL_NAME__ == 0,       "GetSubItemWidth used to accept an INT as the second parameter. The value of zero, I believe, should be COL_NAME" );
 	auto maxwidth = GetSubItemWidth( item, column::COL_NAME );
 
-	ASSERT( maxwidth == ( CListCtrl::GetStringWidth( item->m_name ) + 10 ) );
+#ifdef DEBUG
+	//Hmm. I hate MFC.
+	const auto stringWidth = CListCtrl::GetStringWidth( item->m_name ) + 10;
+	ASSERT( ( maxwidth == stringWidth ) || ( maxwidth == ( stringWidth - 1 ) ) || ( maxwidth == ( stringWidth + 1 ) ) );
+#endif
 
 	if ( item->m_child_info.m_child_info_ptr == nullptr ) {
 		TRACE( _T( "item `%s` has a child count of ZERO! Not expanding! \r\n" ), item->m_name );

--- a/WinDirStat/windirstat/TreeListControl.cpp
+++ b/WinDirStat/windirstat/TreeListControl.cpp
@@ -1057,7 +1057,7 @@ int CTreeListControl::collapse_parent_plus_one_through_index( _In_ const CTreeLi
 			}
 		TRACE( _T( "Might collapse item %i (`%s`)\r\n" ), k, item_at_k->m_name );
 		if ( !CollapseItem( k ) ) {
-			TRACE( _T( "Failed to collapse item at `k`: %i (`%s`)\r\n" ), k, item_at_k->m_name );
+			TRACE( _T( "WARNING: Failed to collapse item at `k`: %i (`%s`)\r\n" ), k, item_at_k->m_name );
 			break;
 			}
 		//We need to move UP the hierarchy, so we need to collapse items we're moving UP FROM
@@ -1073,7 +1073,7 @@ void CTreeListControl::adjustColumnSize( _In_ const CTreeListItem* const item_at
 	static_assert( std::is_convertible<std::underlying_type<column::ENUM_COL>::type, int>::value, "we're gonna need to do this!" );
 
 	const auto w = GetSubItemWidth( item_at_index, column::COL_NAME ) + 5;
-	ASSERT( w == ( CListCtrl::GetStringWidth( item_at_index->m_name ) + 15 ) );
+
 	const auto colWidth = CListCtrl::GetColumnWidth( static_cast<int>( column::COL_NAME ) );
 	if ( colWidth < w ) {
 		VERIFY( CListCtrl::SetColumnWidth( 0, w + colWidth ) );
@@ -1661,7 +1661,7 @@ void CTreeListControl::ToggleExpansion( _In_ _In_range_( 0, INT_MAX ) const INT 
 		}
 	//SetRedraw( FALSE );
 	if ( item_at_i->IsExpanded( ) ) {
-		VERIFY( CollapseItem( i ) );
+		CollapseItem( i );//Ok to ignore return value here.
 		//SetRedraw( TRUE );
 		return;
 		}
@@ -1700,7 +1700,8 @@ _Success_( return == true ) bool CTreeListControl::CollapseItem( _In_ _In_range_
 		return false;
 		}
 	if ( !item->IsExpanded( ) ) {
-		TRACE( _T( "ERROR: Collapsing item %i: %s...it's not expanded!\r\n" ), i, item->m_name );
+		TRACE( _T( "WARNING: Collapsing item %i: %s...it's not expanded!\r\n" ), i, item->m_name );
+		TRACE( _T( "WARNING: The aforemention collapse failure (\"it's not expanded!\") is not cause for concern if you're collapsing a folder (hitting left) from something OTHER than the first item in that folder.\r\n" ) );
 		return false;
 		}
 	TRACE( _T( "Collapsing item %i: %s, item count prior to collapsing: %i\r\n" ), i, item->m_name, CListCtrl::GetItemCount( ) );
@@ -1899,7 +1900,7 @@ void CTreeListControl::ExpandItem( _In_ _In_range_( 0, INT_MAX ) const int i, _I
 
 void CTreeListControl::handle_VK_LEFT( _In_ const CTreeListItem* const item, _In_ _In_range_( 0, INT32_MAX ) const int i ) {
 	if ( item->IsExpanded( ) ) {
-		VERIFY( CollapseItem( i ) );
+		CollapseItem( i );//Ok to ignore return value here.
 		}
 	else if ( item->m_parent != NULL ) {
 		SelectItem( item->m_parent );

--- a/WinDirStat/windirstat/TreeListControl.h
+++ b/WinDirStat/windirstat/TreeListControl.h
@@ -292,7 +292,9 @@ class CTreeListControl final : public COwnerDrawnListCtrl {
 				anItem->SetVisible( false );
 				anItem->m_vi.reset( );
 				}
-			VERIFY( CListCtrl::DeleteItem( i ) );
+			if ( !CListCtrl::DeleteItem( i ) ) {
+				std::terminate( );
+				}
 			}
 
 		//calls CWnd::DestroyWindow( )

--- a/WinDirStat/windirstat/TreeListControl.h
+++ b/WinDirStat/windirstat/TreeListControl.h
@@ -59,7 +59,7 @@ struct VISIBLEINFO final {
 // m_vi is freed as soon as the item is removed from the List.
 class CTreeListItem final : public COwnerDrawnListItem {
 	
-		virtual bool   DrawSubitem( RANGE_ENUM_COL const column::ENUM_COL subitem, _In_ CDC& pdc, _In_ RECT rc, _In_ const UINT state, _Out_opt_ INT* const width, _Inout_ INT* const focusLeft, _In_ const COwnerDrawnListCtrl* const list ) const override final;
+		virtual bool   DrawSubitem( RANGE_ENUM_COL const column::ENUM_COL subitem, _In_ HDC hDC, _In_ RECT rc, _In_ const UINT state, _Out_opt_ INT* const width, _Inout_ INT* const focusLeft, _In_ const COwnerDrawnListCtrl* const list ) const override final;
 		
 		virtual INT Compare( _In_ const COwnerDrawnListItem* const other, RANGE_ENUM_COL const column::ENUM_COL subitem                          ) const override final;
 
@@ -328,9 +328,9 @@ class CTreeListControl final : public COwnerDrawnListCtrl {
 				void handle_VK_LEFT                            ( _In_     const CTreeListItem* const item,     _In_ _In_range_( 0, INT32_MAX ) const int i );
 				
 		_Pre_satisfies_( item->m_vi._Myptr != nullptr ) _Success_( return )
-				const bool DrawNodeNullWidth                   ( _In_     const CTreeListItem* const item, _In_ CDC& pdc, _In_ const RECT& rcRest, _In_    CDC& dcmem, _In_ const UINT ysrc ) const;
-				RECT DrawNode_Indented                         ( _In_     const CTreeListItem* const item, _In_ CDC& pdc, _Inout_    RECT& rc,     _Inout_ RECT& rcRest ) const;
-				RECT DrawNode                                  ( _In_     const CTreeListItem* const item, _In_ CDC& pdc, _Inout_    RECT& rc            ) const;
+				const bool DrawNodeNullWidth                   ( _In_     const CTreeListItem* const item, _In_ HDC hDC,  _In_ const RECT& rcRest, _In_    HDC hDCmem, _In_ const UINT ysrc ) const;
+				RECT DrawNode_Indented                         ( _In_     const CTreeListItem* const item, _In_ HDC hDC, _Inout_    RECT& rc,     _Inout_ RECT& rcRest ) const;
+				RECT DrawNode                                  ( _In_     const CTreeListItem* const item, _In_ HDC hDC, _Inout_    RECT& rc            ) const;
 
 		_Pre_satisfies_( ( parent + 1 ) < index ) _Ret_range_( -1, INT_MAX ) 
 				int  collapse_parent_plus_one_through_index    ( _In_     const CTreeListItem*       thisPath, const int index, _In_range_( 0, INT_MAX ) const int parent );

--- a/WinDirStat/windirstat/TreeListControl.h
+++ b/WinDirStat/windirstat/TreeListControl.h
@@ -47,7 +47,7 @@ struct VISIBLEINFO final {
 
 	                          SRECT                        rcPlusMinus;     // Coordinates of the little +/- rectangle, relative to the upper left corner of the item.
 	                          SRECT                        rcTitle;         // Coordinates of the label, relative to the upper left corner of the item.
-	                          std::vector<CTreeListItem *> cache_sortedChildren; // cache_sortedChildren: This member contains our children (the same set of children as in CItem::m_children) and is initialized as soon as we are expanded. // In contrast to CItem::m_children, this array is always sorted depending on the current user-defined sort column and -order.
+	                          std::vector<const CTreeListItem *> cache_sortedChildren; // cache_sortedChildren: This member contains our children (the same set of children as in CItem::m_children) and is initialized as soon as we are expanded. // In contrast to CItem::m_children, this array is always sorted depending on the current user-defined sort column and -order.
 	_Field_range_( 0, 32767 ) std::int16_t                 indent;  // 0 for the root item, 1 for its children, and so on.
 		                      bool                         isExpanded : 1; // Whether item is expanded.
 							  double                       ntfs_compression_ratio;
@@ -138,7 +138,7 @@ class CTreeListItem final : public COwnerDrawnListItem {
 
 		DOUBLE  GetFraction                   (                                                                   ) const;
 
-		std::vector<CTreeListItem*> size_sorted_vector_of_children( ) const;
+		std::vector<const CTreeListItem*> size_sorted_vector_of_children( ) const;
 
 		void    UpwardGetPathWithoutBackslash ( std::wstring& pathBuf ) const;
 
@@ -162,7 +162,7 @@ class CTreeListItem final : public COwnerDrawnListItem {
 		void    stdRecurseCollectExtensionData( _Inout_    std::unordered_map<std::wstring, minimal_SExtensionRecord>& extensionMap ) const;
 
 		_Success_( return != NULL ) _Must_inspect_result_ _Ret_maybenull_ 
-		CTreeListItem* GetSortedChild   ( _In_ const size_t i                             ) const;
+		const CTreeListItem* GetSortedChild   ( _In_ const size_t i                             ) const;
 
 		_Success_( return < child_count ) _Pre_satisfies_( child_count > 0 )
 		size_t  FindSortedChild                 ( _In_ const CTreeListItem* const child, _In_ const size_t child_count ) const;

--- a/WinDirStat/windirstat/datastructures.cpp
+++ b/WinDirStat/windirstat/datastructures.cpp
@@ -111,7 +111,10 @@ CSetTextColor::~CSetTextColor( ) {
 		std::terminate( );
 		abort( );
 		}
-	::SetTextColor( m_hDC, m_oldColor );
+	const COLORREF result = ::SetTextColor( m_hDC, m_oldColor );
+	if ( result == CLR_INVALID ) {
+		std::terminate( );
+		}
 	//m_pdc->SetTextColor( m_oldColor );
 	}
 

--- a/WinDirStat/windirstat/datastructures.cpp
+++ b/WinDirStat/windirstat/datastructures.cpp
@@ -49,25 +49,6 @@ CSelectObject::~CSelectObject( ) {
 
 
 CSelectStockObject::CSelectStockObject( _In_ HDC hDC, _In_ _In_range_( 0, 16 ) const INT nIndex ) : m_hDC { hDC } {
-	//"Return Value: A pointer to the CGdiObject object that was replaced if the function is successful. The actual object pointed to is a CPen, CBrush, or CFont object. If the call is unsuccessful, the return value is NULL."
-	/*
-	CGdiObject* CDC::SelectStockObject(int nIndex)
-	{
-		ASSERT(m_hDC != NULL);
-
-		HGDIOBJ hObject = ::GetStockObject(nIndex);
-		HGDIOBJ hOldObj = NULL;
-
-		ASSERT(hObject != NULL);
-		if (m_hDC != m_hAttribDC)
-			hOldObj = ::SelectObject(m_hDC, hObject);
-		if (m_hAttribDC != NULL)
-			hOldObj = ::SelectObject(m_hAttribDC, hObject);
-		return CGdiObject::FromHandle(hOldObj);
-	}
-
-	
-	*/
 	if ( m_hDC == NULL ) {
 		std::terminate( );
 		}

--- a/WinDirStat/windirstat/datastructures.cpp
+++ b/WinDirStat/windirstat/datastructures.cpp
@@ -12,6 +12,14 @@
 
 
 CSelectObject::CSelectObject( _In_ const HDC hDC, _In_ const HGDIOBJ hObject ) : m_hDC{ hDC } {
+	//SelectObject function: https://msdn.microsoft.com/en-us/library/dd162957.aspx
+	//If the selected object is not a region and the function succeeds, the return value is a handle to the object being replaced.
+	//If the selected object is a region and the function succeeds, the return value is one of the following values.
+		//SIMPLEREGION
+		//COMPLEXREGION
+		//NULLREGION
+	//If an error occurs and the selected object is not a region, the return value is NULL.
+	//Otherwise, it is HGDI_ERROR.
 	m_pOldObject = ::SelectObject( m_hDC, hObject );
 	if ( m_pOldObject == NULL ) {
 		std::terminate( );
@@ -22,6 +30,14 @@ CSelectObject::CSelectObject( _In_ const HDC hDC, _In_ const HGDIOBJ hObject ) :
 	}
 
 CSelectObject::~CSelectObject( ) {
+	//SelectObject function: https://msdn.microsoft.com/en-us/library/dd162957.aspx
+	//If the selected object is not a region and the function succeeds, the return value is a handle to the object being replaced.
+	//If the selected object is a region and the function succeeds, the return value is one of the following values.
+		//SIMPLEREGION
+		//COMPLEXREGION
+		//NULLREGION
+	//If an error occurs and the selected object is not a region, the return value is NULL.
+	//Otherwise, it is HGDI_ERROR.
 	const HGDIOBJ retval = ::SelectObject( m_hDC, m_pOldObject );
 	if ( retval == NULL ) {
 		std::terminate( );
@@ -55,11 +71,25 @@ CSelectStockObject::CSelectStockObject( _In_ HDC hDC, _In_ _In_range_( 0, 16 ) c
 	if ( m_hDC == NULL ) {
 		std::terminate( );
 		}
+
+	//GetStockObject function: https://msdn.microsoft.com/en-us/library/dd144925.aspx
+	//If the function succeeds, the return value is a handle to the requested logical object.
+	//If the function fails, the return value is NULL.
+	//It is not necessary (but it is not harmful) to delete stock objects by calling DeleteObject.
 	HGDIOBJ hStockObj = ::GetStockObject( nIndex );
 	if ( hStockObj == NULL ) {
 		std::terminate( );
 		abort( );
 		}
+
+	//SelectObject function: https://msdn.microsoft.com/en-us/library/dd162957.aspx
+	//If the selected object is not a region and the function succeeds, the return value is a handle to the object being replaced.
+	//If the selected object is a region and the function succeeds, the return value is one of the following values.
+		//SIMPLEREGION
+		//COMPLEXREGION
+		//NULLREGION
+	//If an error occurs and the selected object is not a region, the return value is NULL.
+	//Otherwise, it is HGDI_ERROR.
 	m_pOldObject = ::SelectObject( m_hDC, hStockObj );
 
 	//m_pOldObject = pdc.SelectStockObject( nIndex );
@@ -67,7 +97,14 @@ CSelectStockObject::CSelectStockObject( _In_ HDC hDC, _In_ _In_range_( 0, 16 ) c
 	}
 
 CSelectStockObject::~CSelectStockObject( ) {
-	//"Return Value: A pointer to the object being replaced. This is a pointer to an object of one of the classes derived from CGdiObject, such as CPen, depending on which version of the function is used. The return value is NULL if there is an error. This function may return a pointer to a temporary object. This temporary object is only valid during the processing of one Windows message. For more information, see CGdiObject::FromHandle."
+	//SelectObject function: https://msdn.microsoft.com/en-us/library/dd162957.aspx
+	//If the selected object is not a region and the function succeeds, the return value is a handle to the object being replaced.
+	//If the selected object is a region and the function succeeds, the return value is one of the following values.
+		//SIMPLEREGION
+		//COMPLEXREGION
+		//NULLREGION
+	//If an error occurs and the selected object is not a region, the return value is NULL.
+	//Otherwise, it is HGDI_ERROR.
 	const auto retval = ::SelectObject( m_hDC, m_pOldObject );
 	if ( retval == NULL ) {
 		std::terminate( );
@@ -82,8 +119,13 @@ CSetBkMode::CSetBkMode( _In_ HDC hDC, _In_ const INT mode ) : m_hDC { hDC } {
 	if ( hDC == NULL ) {
 		std::terminate( );
 		}
+
+	//SetBkMode function: https://msdn.microsoft.com/en-us/library/dd162965.aspx
+	//If the function succeeds, the return value specifies the previous background mode.
+	//If the function fails, the return value is zero.
 	m_oldMode = ::SetBkMode( m_hDC, mode );
 	//m_oldMode = pdc.SetBkMode( mode );
+	ASSERT( m_oldMode != 0 );
 	}
 
 CSetBkMode::~CSetBkMode( ) {
@@ -91,7 +133,11 @@ CSetBkMode::~CSetBkMode( ) {
 		std::terminate( );
 		abort( );
 		}
-	::SetBkMode( m_hDC, m_oldMode );
+	ASSERT( m_oldMode != 0 );
+	//SetBkMode function: https://msdn.microsoft.com/en-us/library/dd162965.aspx
+	//If the function succeeds, the return value specifies the previous background mode.
+	//If the function fails, the return value is zero.
+	VERIFY( ::SetBkMode( m_hDC, m_oldMode ) );
 	//m_pdc->SetBkMode( m_oldMode );
 	}
 
@@ -101,6 +147,10 @@ CSetTextColor::CSetTextColor( _In_ HDC hDC, _In_ const COLORREF color ) : m_hDC 
 		}
 	//ASSERT_VALID( pdc );
 	//m_oldColor = pdc.SetTextColor( color );
+	
+	//SetTextColor function: https://msdn.microsoft.com/en-us/library/dd145093.aspx
+	//If the function succeeds, the return value is a color reference for the previous text color as a COLORREF value.
+	//If the function fails, the return value is CLR_INVALID.
 	m_oldColor = ::SetTextColor( hDC, color );
 	ASSERT( m_oldColor != CLR_INVALID );
 	}
@@ -111,6 +161,9 @@ CSetTextColor::~CSetTextColor( ) {
 		std::terminate( );
 		abort( );
 		}
+	//SetTextColor function: https://msdn.microsoft.com/en-us/library/dd145093.aspx
+	//If the function succeeds, the return value is a color reference for the previous text color as a COLORREF value.
+	//If the function fails, the return value is CLR_INVALID.
 	const COLORREF result = ::SetTextColor( m_hDC, m_oldColor );
 	if ( result == CLR_INVALID ) {
 		std::terminate( );

--- a/WinDirStat/windirstat/datastructures.h
+++ b/WinDirStat/windirstat/datastructures.h
@@ -13,54 +13,54 @@ WDS_FILE_INCLUDE_MESSAGE
 
 class CSelectObject final {
 public:
-	CSelectObject( _In_ CDC& pdc, _In_ CGdiObject& pObject );
+	CSelectObject( _In_ const HDC hDC, _In_ const HGDIOBJ hObject );
 	~CSelectObject( );
 
 	CSelectObject( const CSelectObject& in ) = delete;
 	CSelectObject& operator=( const CSelectObject& rhs ) = delete;
 protected:
-	CDC* const m_pdc;
-	CGdiObject* m_pOldObject;
+	const HDC m_hDC;
+	HGDIOBJ m_pOldObject;
 	};
 
 class CSelectStockObject final {
 public:
-	CSelectStockObject( _In_ CDC& pdc, _In_ _In_range_( 0, 16 ) const INT nIndex );
+	CSelectStockObject( _In_ HDC hDC, _In_ _In_range_( 0, 16 ) const INT nIndex );
 
 	~CSelectStockObject( );
 
 	CSelectStockObject( const CSelectStockObject& in ) = delete;
 	CSelectStockObject& operator=( const CSelectStockObject& rhs ) = delete;
 protected:
-	CDC* const  m_pdc;
-	CGdiObject* m_pOldObject;
+	const HDC m_hDC;
+	HGDIOBJ m_pOldObject;
 	};
 
 class CSetBkMode final {
 public:
 	_Pre_satisfies_( ( mode == OPAQUE ) || ( mode == TRANSPARENT ) )
-	CSetBkMode( _In_ CDC& pdc, _In_ const INT mode );
+	CSetBkMode( _In_ HDC hDC, _In_ const INT mode );
 	
 	~CSetBkMode( );
 
 	CSetBkMode( const CSetBkMode& in ) = delete;
 	CSetBkMode& operator=( const CSetBkMode& rhs ) = delete;
 protected:
-	CDC* const m_pdc;
+	HDC m_hDC;
 	//C4820: 'CSetBkMode' : '4' bytes padding added after data member 'CSetBkMode::m_oldMode'
 	int  m_oldMode;
 	};
 
 class CSetTextColor final {
 public:
-	CSetTextColor( _In_ CDC& pdc, _In_ const COLORREF color );
+	CSetTextColor( _In_ HDC hDC, _In_ const COLORREF color );
 
 	~CSetTextColor( );
 
 	CSetTextColor( const CSetTextColor& in ) = delete;
 	CSetTextColor& operator=( const CSetTextColor& rhs ) = delete;
 protected:
-	CDC* const m_pdc;
+	const HDC m_hDC;
 	//C4820: 'CSetTextColor' : '4' bytes padding added after data member 'CSetTextColor::m_oldColor'
 	COLORREF m_oldColor;
 	};

--- a/WinDirStat/windirstat/directory_enumeration.cpp
+++ b/WinDirStat/windirstat/directory_enumeration.cpp
@@ -258,27 +258,27 @@ namespace {
 		L"$Boot",
 		L"$BadClus",
 		L"$Secure",
-		L"$UpCase",
+		L"$Upcase",
 		L"$Extend"
 	};
 
-	void handle_NTFS_special_files( const std::wstring& path, _In_ const CDirstatApp* const app, _Inout_ std::vector<FILEINFO>* const files, _Inout_ std::vector<DIRINFO>* directories ) {
-		const bool is_mount_point = app->m_mountPoints.IsMountPoint( path );
-		if ( !is_mount_point ) {
-			TRACE( _T( "Path: `%s` is NOT a mount point, so it can't have NTFS special files in it's first level child directory!\r\n" ), path.c_str( ) );
-			return;
-			}
+	void handle_NTFS_special_files( const std::wstring& path/*, _In_ const CDirstatApp* const app*/, _Inout_ std::vector<FILEINFO>& files, _Inout_ std::vector<DIRINFO>& directories ) {
+		//const bool is_mount_point = app->m_mountPoints.IsMountPoint( path );
+		//if ( !is_mount_point ) {
+		//	TRACE( _T( "Path: `%s` is NOT a mount point, so it can't have NTFS special files in it's first level child directory!\r\n" ), path.c_str( ) );
+		//	return;
+		//	}
 
 		//path + _T( "\\*.*" )
 
 		for ( size_t i = 0u; i < _countof( NTFS_SPECIAL_FILES ); ++i ) {
 			std::wstring path_to_special_file( path );
-			path_to_special_file.append( L"\\*.*" );
+			path_to_special_file.append( L"\\" );
 			path_to_special_file.append( NTFS_SPECIAL_FILES[ i ] );
 			if ( !isValidPathToFSObject( path_to_special_file ) ) {
-				continue;
+				//continue;
 				}
-			FindFilesLoop( *files, *directories, path_to_special_file );
+			FindFilesLoop( files, directories, path_to_special_file );
 			}
 		}
 	
@@ -461,8 +461,8 @@ namespace {
 
 		vecFiles.reserve( 50 );//pseudo-arbitrary number
 
-		if ( ThisCItem->m_parent != NULL ) {
-			handle_NTFS_special_files( path, app, &vecFiles, &vecDirs );
+		if ( ThisCItem->m_parent == NULL ) {
+			handle_NTFS_special_files( path/*, app*/, vecFiles, vecDirs );
 			}
 
 		FindFilesLoop( vecFiles, vecDirs, std::move( path + _T( "\\*.*" ) ) );

--- a/WinDirStat/windirstat/directory_enumeration.cpp
+++ b/WinDirStat/windirstat/directory_enumeration.cpp
@@ -253,6 +253,10 @@ namespace {
 			TRACE( _T( "Error! File path: %s, File path length: %i. Failed to get error message for error code: %u\r\n" ), path.c_str( ), path.length( ), last_err );
 			return;
 			}
+#else
+		UNREFERENCED_PARAMETER( path );
+		UNREFERENCED_PARAMETER( ret );
+		UNREFERENCED_PARAMETER( last_err );
 #endif
 		return;
 		}

--- a/WinDirStat/windirstat/directory_enumeration.cpp
+++ b/WinDirStat/windirstat/directory_enumeration.cpp
@@ -119,11 +119,6 @@ WDS_DECLSPEC_NOTHROW void FindFilesLoop( _Inout_ std::vector<FILEINFO>& files, _
 	WIN32_FIND_DATA fData;
 	HANDLE fDataHand = NULL;
 	fDataHand = FindFirstFileExW( path.c_str( ), FindExInfoBasic, &fData, FindExSearchNameMatch, NULL, 0 );
-	//FILETIME t;
-	//FILEINFO fi;
-	//zeroFILEINFO( fi );
-	//memset_zero_struct( fi );
-	//fi.reset( );
 	BOOL findNextFileRes = TRUE;
 	while ( ( fDataHand != INVALID_HANDLE_VALUE ) && ( findNextFileRes != 0 ) ) {
 		const auto scmpVal  = wcscmp( fData.cFileName, L".." );
@@ -412,6 +407,19 @@ namespace {
 	
 	//return indicates whether we should ask user to elevate
 	bool handle_NTFS_special_files( _In_ const std::wstring& path, _In_ const CDirstatApp* const app, _Inout_ std::vector<FILEINFO>& files, _Inout_ std::vector<DIRINFO>& directories ) {
+		if ( path.length( ) > 5 ) {
+			ASSERT( path.compare( 0, 4, L"\\\\?\\", 4 ) == 0 );
+			std::wstring path_temp( path.cbegin( ) + 4, path.cend( ) );
+			path_temp += L"\\";
+			if ( app->m_mountPoints.IsVolume( path_temp ) ) {
+				TRACE( _T( "path: `%s` is a volume\r\n" ), path_temp.c_str( ) );
+				}
+			else {
+				TRACE( _T( "path: `%s` is NOT a volume\r\n" ), path_temp.c_str( ) );
+				return false;
+				}
+			}
+
 		std::wstring raw_dir_path( fixup_path_to_MFT( path ) );
 
 

--- a/WinDirStat/windirstat/directory_enumeration.cpp
+++ b/WinDirStat/windirstat/directory_enumeration.cpp
@@ -174,7 +174,26 @@ namespace {
 		L"$BadClus",
 		L"$Secure",
 		L"$Upcase",
-		L"$Extend"
+		L"$Extend",
+		L"$ObjId",      //Windows 8.1 only? http://blogs.msdn.com/b/ntdebugging/archive/2014/05/08/ntfs-misreports-free-space-part-3.aspx
+		                //fsutil queries "\\.\C:\$Extend\$ObjId:$O:$INDEX_ALLOCATION"
+		L"$Quota",      //fsutil queries "\\.\C:\$Extend\$Quota:$Q:$INDEX_ALLOCATION"
+		L"$Reparse",    //fsutil queries "\\.\C:\$Extend\$Reparse:$R:$INDEX_ALLOCATION"
+		L"$UsnJrnl",    //fsutil queries "\\.\C:\$Extend\$UsnJrnl:$J"
+		L"$RmMetadata", //Also Win 8.1 only?
+		                //fsutil queries "\\.\C:\$Extend\$RmMetadata"
+		L"$Repair",     //Also Win 8.1 only?
+		                //fsutil queries "\\.\C:\$Extend\$RmMetadata\$Repair"
+		L"$Txf",        //Also Win 8.1 only?
+		                //fsutil queries "\\.\C:\$Extend\$RmMetadata\$Txf"
+		L"$TxfLog"      //Also Win 8.1 only?
+		                //fsutil queries "\??\C:\$Extend\$RmMetadata\$TxfLog"
+		L"$Tops",       //Also Win 8.1 only?
+		                //fsutil queries "\\.\C:\$Extend\$RmMetadata\$TxfLog\$Tops"
+		L"$TxfLog.blf", //Also Win 8.1 only?
+		                //fsutil queries "\\.\C:\$Extend\$RmMetadata\$TxfLog\$TxfLog.blf"
+
+		//System Volume Information?
 	};
 
 
@@ -377,6 +396,7 @@ namespace {
 			return;
 			}
 
+		//file_info->
 		(void)files;//temporarily suppress warning
 
 		close_handle( special_file_handle );

--- a/WinDirStat/windirstat/directory_enumeration.cpp
+++ b/WinDirStat/windirstat/directory_enumeration.cpp
@@ -271,15 +271,7 @@ namespace {
 		L"$Extend"
 	};
 
-	void handle_NTFS_special_files( const std::wstring& path/*, _In_ const CDirstatApp* const app*/, _Inout_ std::vector<FILEINFO>& files, _Inout_ std::vector<DIRINFO>& directories ) {
-		//const bool is_mount_point = app->m_mountPoints.IsMountPoint( path );
-		//if ( !is_mount_point ) {
-		//	TRACE( _T( "Path: `%s` is NOT a mount point, so it can't have NTFS special files in it's first level child directory!\r\n" ), path.c_str( ) );
-		//	return;
-		//	}
-
-		//path + _T( "\\*.*" )
-		//
+	void handle_NTFS_special_files( const std::wstring& path, _In_ const CDirstatApp* const app, _Inout_ std::vector<FILEINFO>& files, _Inout_ std::vector<DIRINFO>& directories ) {
 		std::wstring raw_dir_path( path );
 		ASSERT( path.length( ) > 5 );
 		if ( path.length( ) > 5 ) {
@@ -287,6 +279,16 @@ namespace {
 			raw_dir_path = std::wstring( path.cbegin( ) + 4, path.cbegin( ) + 6 );
 			TRACE( L"raw_dir_path: `%s`\r\n", raw_dir_path.c_str( ) );
 			}
+
+
+		const bool is_mount_point = app->m_mountPoints.IsVolume( raw_dir_path + L"\\" );
+		if ( !is_mount_point ) {
+			TRACE( _T( "Path: `%s` is NOT a mount point, so it can't have NTFS special files in it's first level child directory!\r\n" ), raw_dir_path.c_str( ) );
+			return;
+			}
+
+		//path + _T( "\\*.*" )
+		//
 
 		ASSERT( raw_dir_path.length( ) > 0 );
 
@@ -519,7 +521,7 @@ namespace {
 		vecFiles.reserve( 50 );//pseudo-arbitrary number
 
 		if ( ThisCItem->m_parent == NULL ) {
-			handle_NTFS_special_files( path/*, app*/, vecFiles, vecDirs );
+			handle_NTFS_special_files( path, app, vecFiles, vecDirs );
 			}
 
 		FindFilesLoop( vecFiles, vecDirs, std::move( path + _T( "\\*.*" ) ) );

--- a/WinDirStat/windirstat/directory_enumeration.h
+++ b/WinDirStat/windirstat/directory_enumeration.h
@@ -27,7 +27,7 @@ class CDirstatApp;
 
 //_Pre_satisfies_( !ThisCItem->m_attr.m_done ) std::pair<std::vector<std::pair<CItemBranch*, std::wstring>>,std::vector<std::pair<CItemBranch*, std::wstring>>>    readJobNotDoneWork            ( _In_ CItemBranch* const ThisCItem, std::wstring path, _In_ const CDirstatApp* app );
 
-DOUBLE    DoSomeWorkShim                ( _Inout_ CTreeListItem* const ThisCItem, std::wstring path, _In_ const CDirstatApp* app, const bool isRootRecurse = false );
+std::pair<DOUBLE, bool>    DoSomeWorkShim                ( _Inout_ CTreeListItem* const ThisCItem, std::wstring path, _In_ const CDirstatApp* app, const bool isRootRecurse = false );
 
 
 

--- a/WinDirStat/windirstat/directory_enumeration.h
+++ b/WinDirStat/windirstat/directory_enumeration.h
@@ -27,7 +27,7 @@ class CDirstatApp;
 
 //_Pre_satisfies_( !ThisCItem->m_attr.m_done ) std::pair<std::vector<std::pair<CItemBranch*, std::wstring>>,std::vector<std::pair<CItemBranch*, std::wstring>>>    readJobNotDoneWork            ( _In_ CItemBranch* const ThisCItem, std::wstring path, _In_ const CDirstatApp* app );
 
-DOUBLE    DoSomeWorkShim                ( _In_ CTreeListItem* const ThisCItem, std::wstring path, _In_ const CDirstatApp* app, const bool isRootRecurse = false );
+DOUBLE    DoSomeWorkShim                ( _Inout_ CTreeListItem* const ThisCItem, std::wstring path, _In_ const CDirstatApp* app, const bool isRootRecurse = false );
 
 
 

--- a/WinDirStat/windirstat/dirstatdoc.cpp
+++ b/WinDirStat/windirstat/dirstatdoc.cpp
@@ -446,7 +446,10 @@ bool CDirstatDoc::Work( ) {
 			TRACE( _T( "path fixed as: %s\r\n" ), path.c_str( ) );
 			}
 		const auto thisApp = m_appptr;
-		m_compressed_file_timing = DoSomeWorkShim( m_rootItem.get( ), std::move( path ), thisApp, true );
+		
+		auto timing_and_elevate = DoSomeWorkShim( m_rootItem.get( ), std::move( path ), thisApp, true );
+		m_compressed_file_timing = timing_and_elevate.first;
+		const bool should_we_elevate = timing_and_elevate.second;
 		ASSERT( m_rootItem->m_attr.m_done );
 		
 		//cache the size of root item
@@ -462,6 +465,9 @@ bool CDirstatDoc::Work( ) {
 			}
 		
 		m_rootItem->AddChildren( &( DirStatView->m_treeListControl ) );
+		if ( should_we_elevate ) {
+			displayWindowsMsgBoxWithMessage( L"Couldn't query MFT file size, as Windows denied access. If you'd like to see the size of the MFT, run as an administrator." );
+			}
 		return res;
 		}
 	return false;

--- a/WinDirStat/windirstat/dirstatview.cpp
+++ b/WinDirStat/windirstat/dirstatview.cpp
@@ -84,6 +84,7 @@ void CDirstatView::OnUpdateHINT_SELECTIONCHANGED( ) {
 		TRACE( _T( "I was told that the selection changed, but found a NULL selection. I can neither select nor show NULL - What would that even mean??\r\n" ) );
 		return;
 		}
+	TRACE( _T( "Selection changed to: %s\r\n" ), Selection->m_name );
 	m_treeListControl.SelectAndShowItem( Selection, false );
 	}
 
@@ -102,6 +103,7 @@ void CDirstatView::OnUpdateHINT_SHOWNEWSELECTION( ) {
 		}
 	TRACE( _T( "New item selected! item: %s\r\n" ), Selection->GetPath( ).c_str( ) );
 	m_treeListControl.SelectAndShowItem( Selection, true );
+	CWnd::RedrawWindow( );
 	}
 
 

--- a/WinDirStat/windirstat/dirstatview.cpp
+++ b/WinDirStat/windirstat/dirstatview.cpp
@@ -84,7 +84,7 @@ void CDirstatView::OnUpdateHINT_SELECTIONCHANGED( ) {
 		TRACE( _T( "I was told that the selection changed, but found a NULL selection. I can neither select nor show NULL - What would that even mean??\r\n" ) );
 		return;
 		}
-	TRACE( _T( "Selection changed to: %s\r\n" ), Selection->m_name );
+	TRACE( _T( "Selection changed to: %s\r\n" ), Selection->GetPath( ).c_str( ) );
 	m_treeListControl.SelectAndShowItem( Selection, false );
 	}
 

--- a/WinDirStat/windirstat/globalhelpers.cpp
+++ b/WinDirStat/windirstat/globalhelpers.cpp
@@ -672,7 +672,7 @@ void wds_fmt::write_bad_fmt_msg( _Out_writes_z_( 41 ) _Pre_writable_size_( 42 ) 
 //This is an error handling function, and is intended to be called rarely!
 __declspec(noinline)
 void displayWindowsMsgBoxWithError( const DWORD error ) {
-	const rsize_t err_msg_size = 1024;
+	const rsize_t err_msg_size = 1024u;
 	_Null_terminated_ wchar_t err_msg[ err_msg_size ] = { 0 };
 	rsize_t chars_written = 0;
 
@@ -685,7 +685,7 @@ void displayWindowsMsgBoxWithError( const DWORD error ) {
 		}
 	TRACE( _T( "First attempt to get last error as a formatted message FAILED!\r\n" ) );
 
-	const rsize_t err_msg_size_2 = 4096;
+	const rsize_t err_msg_size_2 = 4096u;
 	_Null_terminated_ wchar_t err_msg_2[ err_msg_size_2 ] = { 0 };
 	rsize_t chars_written_2 = 0;
 	const HRESULT err_res_2 = CStyle_GetLastErrorAsFormattedMessage( err_msg_2, err_msg_size_2, chars_written_2, error );

--- a/WinDirStat/windirstat/graphview.cpp
+++ b/WinDirStat/windirstat/graphview.cpp
@@ -513,7 +513,7 @@ void trace_mouse_left( ) {
 
 //this function exists for the singular purpose of tracing to console, as doing so from a .cpp is cleaner.
 void trace_focused_mouspos( _In_ const LONG x, _In_ const LONG y, _In_z_ PCWSTR const path ) {
-	TRACE( _T( "focused & Mouse on tree map!(x: %ld, y: %ld), %s\r\n" ), x, y, path );
+	TRACE( _T( "focused & Mouse on tree map!(x: %ld, y: %ld) - hovering over: `%s`\r\n" ), x, y, path );
 	}
 #endif
 

--- a/WinDirStat/windirstat/graphview.cpp
+++ b/WinDirStat/windirstat/graphview.cpp
@@ -163,7 +163,7 @@ void CGraphView::DrawSelection( _In_ CDC& pdc ) const {
 	CSelectStockObject sobrush( pdc, NULL_BRUSH );
 	const auto Options = GetOptions( );
 	CPen pen( PS_SOLID, 1, Options->m_treemapHighlightColor );
-	CSelectObject sopen( pdc, pen );
+	CSelectObject sopen( pdc, &pen );
 
 	RenderHighlightRectangle( pdc, rc );
 	}
@@ -175,7 +175,7 @@ void CGraphView::DoDraw( _In_ CDC& pDC, _In_ CDC& offscreen_buffer, _In_ RECT& r
 	VERIFY( m_bitmap.CreateCompatibleBitmap( &pDC, m_size.cx, m_size.cy ) );
 	auto guard = WDS_SCOPEGUARD_INSTANCE( [&] { CGraphView::cause_OnIdle_to_be_called_once( ); } );
 
-	CSelectObject sobmp( offscreen_buffer, m_bitmap );
+	CSelectObject sobmp( offscreen_buffer.m_hDC, m_bitmap.m_hObject );
 	const auto Document = STATIC_DOWNCAST( CDirstatDoc, m_pDocument );
 	ASSERT( Document != NULL );
 	if ( Document == NULL ) {
@@ -418,7 +418,7 @@ void CGraphView::DrawHighlightExtension( _In_ CDC& pdc ) const {
 	WTL::CWaitCursor wc;
 
 	CPen pen( PS_SOLID, 1, GetOptions( )->m_treemapHighlightColor );
-	CSelectObject sopen( pdc, pen );
+	CSelectObject sopen( pdc.m_hDC, pen.m_hObject );
 	CSelectStockObject sobrush( pdc, NULL_BRUSH );
 	//auto Document = static_cast< CDirstatDoc* >( m_pDocument );;
 	const auto Document = STATIC_DOWNCAST( CDirstatDoc, m_pDocument );

--- a/WinDirStat/windirstat/graphview.h
+++ b/WinDirStat/windirstat/graphview.h
@@ -192,7 +192,7 @@ protected:
 			}
 		CDC offscreen_buffer;
 		VERIFY( offscreen_buffer.CreateCompatibleDC( &pScreen_Device_Context ) );
-		CSelectObject sobmp( offscreen_buffer, m_dimmed );
+		CSelectObject sobmp( offscreen_buffer.m_hDC, m_dimmed.m_hObject );
 		VERIFY( pScreen_Device_Context.BitBlt( rc.left, rc.top, m_dimmedSize.cx, m_dimmedSize.cy, &offscreen_buffer, 0, 0, SRCCOPY ) );
 
 		if ( ( rc.right - rc.left ) > m_dimmedSize.cx ) {
@@ -236,7 +236,7 @@ protected:
 			DoDraw( Screen_Device_Context, offscreen_buffer, rc );
 			}
 
-		CSelectObject sobmp2( offscreen_buffer, m_bitmap );
+		CSelectObject sobmp2( offscreen_buffer.m_hDC, m_bitmap.m_hObject );
 		VERIFY( Screen_Device_Context.BitBlt( 0, 0, m_size.cx, m_size.cy, &offscreen_buffer, 0, 0, SRCCOPY ) );
 
 		DrawHighlights( Screen_Device_Context );

--- a/WinDirStat/windirstat/macros_that_scare_small_children.h
+++ b/WinDirStat/windirstat/macros_that_scare_small_children.h
@@ -1,4 +1,6 @@
 // see `file_header_text.txt` for licensing & contact info. If you can't find that file, then assume you're NOT allowed to do whatever you wanted to do.
+// Funny name of this file is a reference to the Google C++ style guide.
+
 #pragma once
 
 #ifndef MACROS_THAT_SCARE_SMALL_CHILDREN_H_INCLUDED

--- a/WinDirStat/windirstat/mainframe.cpp
+++ b/WinDirStat/windirstat/mainframe.cpp
@@ -409,6 +409,9 @@ void CMainFrame::OnClose( ) {
 	CFrameWnd::SaveBarState( CPersistence::GetBarStateSection( ) );
 	CPersistence::SetShowStatusbar( ( m_wndStatusBar.GetStyle( ) bitand WS_VISIBLE ) != 0 );
 
+	const auto Options = GetOptions( );
+	Options->SaveToRegistry( );
+
 #ifdef _DEBUG
 	// avoid memory leaks and show hourglass while deleting the tree
 	//VERIFY( GetDocument( )->OnNewDocument( ) );

--- a/WinDirStat/windirstat/mountpoints.cpp
+++ b/WinDirStat/windirstat/mountpoints.cpp
@@ -267,6 +267,7 @@ void CMountPoints::GetAllMountPoints( ) {
 	ASSERT( lastErr == ERROR_NO_MORE_FILES );
 
 	if ( lastErr != ERROR_NO_MORE_FILES ) {
+		//TODO: WTF?
 
 		}
 

--- a/WinDirStat/windirstat/mountpoints.h
+++ b/WinDirStat/windirstat/mountpoints.h
@@ -43,6 +43,8 @@ public:
 
 	const bool IsMountPoint( _In_ const std::wstring& path ) const;
 
+	const bool IsVolume( _In_ const std::wstring& path ) const;
+
 	
 private:
 	void Clear( );

--- a/WinDirStat/windirstat/options.cpp
+++ b/WinDirStat/windirstat/options.cpp
@@ -471,6 +471,7 @@ void COptions::SetListGrid( _In_ const bool show ) {
 
 void COptions::SetListStripes( _In_ const bool show ) {
 	if ( m_listStripes != show ) {
+		TRACE( _T( "User changed \"show list stripes\" option...\r\n" ) );
 		m_listStripes = show;
 		GetDocument( )->UpdateAllViews( NULL, UpdateAllViews_ENUM::HINT_LISTSTYLECHANGED );
 		}

--- a/WinDirStat/windirstat/options.cpp
+++ b/WinDirStat/windirstat/options.cpp
@@ -346,7 +346,7 @@ void CPersistence::SetArray( _In_ const std::wstring entry, _Inout_ _Pre_writabl
 	}
 
 _Pre_satisfies_( arrSize > 1 )
-void CPersistence::GetArray( _In_ const std::wstring entry, _Out_ _Pre_writable_size_( arrSize ) INT* arr_, const rsize_t arrSize ) {
+void CPersistence::GetArray( _In_ const std::wstring entry, _Out_ _Pre_writable_size_( arrSize ) INT* arr_, const rsize_t arrSize, _In_z_ const PCWSTR defaultValue ) {
 	ASSERT( entry.length( ) != 0 );
 	for ( rsize_t i = 0; i < arrSize; ++i ) {
 		arr_[ i ] = 0;
@@ -355,7 +355,7 @@ void CPersistence::GetArray( _In_ const std::wstring entry, _Out_ _Pre_writable_
 	if ( entry.length( ) == 0 ) {
 		return;
 		}
-	const auto s_temp = CRegistryUser::GetProfileString_( registry_strings::sectionPersistence, entry.c_str( ), _T( "" ) );
+	const auto s_temp = CRegistryUser::GetProfileString_( registry_strings::sectionPersistence, entry.c_str( ), defaultValue );
 	//const DWORD arr_buf_size = MAX_PATH;
 
 	rsize_t current_arr_index = 0;
@@ -638,7 +638,7 @@ std::wstring CRegistryUser::GetProfileString_( _In_z_ const PCWSTR section, _In_
 #endif
 		return std::wstring( reg_data_buffer );
 		}
-	TRACE( _T( "C-Style GetProfileString failed!\r\n" ) );
+	TRACE( _T( "C-Style GetProfileString failed! section `%s`, entry: `%s`, defaultValue: `%s`\r\n" ), section, entry, defaultValue );
 	return std::wstring( AfxGetApp( )->GetProfileStringW( section, entry, defaultValue ).GetString( ) );
 	}
 

--- a/WinDirStat/windirstat/options.h
+++ b/WinDirStat/windirstat/options.h
@@ -149,17 +149,18 @@ public:
 		SetArray( helpers::MakeColumnOrderEntry( name ), arr, arrSize );
 		}
 
-	static void GetColumnOrder( _In_z_ const PCTSTR name, _Out_ _Pre_writable_size_( arrSize ) INT* arr, const rsize_t arrSize ) {
-		GetArray( helpers::MakeColumnOrderEntry( name ), arr, arrSize );
+	static void GetColumnOrder( _In_z_ const PCTSTR name, _Out_ _Pre_writable_size_( arrSize ) INT* arr, const rsize_t arrSize, _In_z_ const PCWSTR defaultValue ) {
+		GetArray( helpers::MakeColumnOrderEntry( name ), arr, arrSize, defaultValue );
 		}
 	
-	static void GetColumnWidths( _In_z_ const PCTSTR name, _Out_ _Pre_writable_size_( arrSize ) INT* arr, const rsize_t arrSize ) {
-		GetArray( helpers::MakeColumnWidthsEntry( name ), arr, arrSize );
+	static void GetColumnWidths( _In_z_ const PCTSTR name, _Out_ _Pre_writable_size_( arrSize ) INT* arr, const rsize_t arrSize, _In_z_ const PCWSTR defaultValue ) {
+		//TODO: BUGBUG: doesn't check return value of ::RegQueryValueExW (in CRegistryUser::GetProfileString_) - should bubble up?
+		GetArray( helpers::MakeColumnWidthsEntry( name ), arr, arrSize, defaultValue );
 		}
 private:
 	
 	_Pre_satisfies_( arrSize > 1 )
-	static void    GetArray               ( _In_ const std::wstring entry, _Out_ _Pre_writable_size_( arrSize ) INT* arr_, const rsize_t arrSize );
+	static void    GetArray               ( _In_ const std::wstring entry, _Out_ _Pre_writable_size_( arrSize ) INT* arr_, const rsize_t arrSize, _In_z_ const PCWSTR defaultValue );
 	
 	_Success_( SUCCEEDED( return ) )
 	static const HRESULT GetRect          ( _In_ const std::wstring entry, _Out_ RECT& rc                  );

--- a/WinDirStat/windirstat/ownerdrawnlistcontrol.h
+++ b/WinDirStat/windirstat/ownerdrawnlistcontrol.h
@@ -332,7 +332,7 @@ protected:
 		VERIFY( ::InflateRect( &rcRest, -( TEXT_X_MARGIN ), -( 0 ) ) );
 
 		RECT rcLabel = rcRest;
-		::DrawTextW( hDC, m_name, static_cast<int>( m_name_length ), &rcLabel, DT_SINGLELINE | DT_VCENTER | DT_WORD_ELLIPSIS | DT_CALCRECT | DT_NOPREFIX | DT_NOCLIP );//DT_CALCRECT modifies rcLabel!!!
+		VERIFY( ::DrawTextW( hDC, m_name, static_cast<int>( m_name_length ), &rcLabel, DT_SINGLELINE | DT_VCENTER | DT_WORD_ELLIPSIS | DT_CALCRECT | DT_NOPREFIX | DT_NOCLIP ) );//DT_CALCRECT modifies rcLabel!!!
 
 		AdjustLabelForMargin( rcRest, rcLabel );
 
@@ -354,7 +354,7 @@ protected:
 		CSetTextColor stc( hDC, textColor );
 
 		if ( width == NULL ) {
-			::DrawTextW( hDC, m_name, static_cast<int>( m_name_length ), &rcRest, DT_SINGLELINE | DT_VCENTER | DT_WORD_ELLIPSIS | DT_NOPREFIX | DT_NOCLIP );
+			VERIFY( ::DrawTextW( hDC, m_name, static_cast<int>( m_name_length ), &rcRest, DT_SINGLELINE | DT_VCENTER | DT_WORD_ELLIPSIS | DT_NOPREFIX | DT_NOCLIP ) );
 			}
 
 		//subtract one from left, add one to right
@@ -363,7 +363,7 @@ protected:
 		*focusLeft = rcLabel.left;
 
 		if ( ( ( state bitand ODS_FOCUS ) != 0 ) && list_has_focus && ( width == NULL ) && ( !( list_is_full_row_selection ) ) ) {
-			::DrawFocusRect( hDC, &rcLabel );
+			VERIFY( ::DrawFocusRect( hDC, &rcLabel ) );
 			rcLabel.left = rc.left;
 			rc = rcLabel;
 			return;
@@ -568,7 +568,7 @@ namespace {
 		for ( ; i < thisLoopSize; i++ ) {
 			if ( focusLefts[ i ] > rects_draw[ i ].left ) {
 				
-				::DrawFocusRect( hDC, &rcFocus );
+				VERIFY( ::DrawFocusRect( hDC, &rcFocus ) );
 				//pdc->DrawFocusRect( &rcFocus );
 				rcFocus.left = focusLefts[ i ];
 				}
@@ -1206,7 +1206,7 @@ public:
 
 		if ( subitem == column::COL_NAME ) {
 			//fastpath. No work to be done!
-			::DrawTextW( hDC, item->m_name, static_cast< int >( item->m_name_length ), &rcText, DT_SINGLELINE | DT_VCENTER | DT_WORD_ELLIPSIS | DT_NOPREFIX | DT_NOCLIP | static_cast< UINT >( align ) );
+			VERIFY( ::DrawTextW( hDC, item->m_name, static_cast< int >( item->m_name_length ), &rcText, DT_SINGLELINE | DT_VCENTER | DT_WORD_ELLIPSIS | DT_NOPREFIX | DT_NOCLIP | static_cast< UINT >( align ) ) );
 			return;
 			}
 
@@ -1230,7 +1230,7 @@ protected:
 		ASSERT( subitem != column::COL_NAME );
 		const HRESULT res = item->GetText_WriteToStackBuffer( subitem, psz_subitem_formatted_text, subitem_text_size, sizeNeeded, chars_written );
 		if ( SUCCEEDED( res ) ) {
-			::DrawTextW( hDC, psz_subitem_formatted_text, static_cast<int>( chars_written ), &rcText, DT_SINGLELINE | DT_VCENTER | DT_WORD_ELLIPSIS | DT_NOPREFIX | DT_NOCLIP | static_cast<UINT>( align ) );
+			VERIFY( ::DrawTextW( hDC, psz_subitem_formatted_text, static_cast<int>( chars_written ), &rcText, DT_SINGLELINE | DT_VCENTER | DT_WORD_ELLIPSIS | DT_NOPREFIX | DT_NOCLIP | static_cast<UINT>( align ) ) );
 			return res;
 			}
 		if ( ( MAX_PATH * 2 ) > sizeNeeded ) {
@@ -1240,7 +1240,7 @@ protected:
 			ASSERT( subitem != column::COL_NAME );
 			const HRESULT res_2 = item->GetText_WriteToStackBuffer( subitem, psz_subitem_formatted_text_2, subitem_text_size_2, sizeNeeded, chars_written_2 );
 			if ( SUCCEEDED( res_2 ) ) {
-				::DrawTextW( hDC, psz_subitem_formatted_text_2, static_cast<int>( chars_written_2 ), &rcText, DT_SINGLELINE | DT_VCENTER | DT_WORD_ELLIPSIS | DT_NOPREFIX | DT_NOCLIP | static_cast<UINT>( align ) );
+				VERIFY( ::DrawTextW( hDC, psz_subitem_formatted_text_2, static_cast<int>( chars_written_2 ), &rcText, DT_SINGLELINE | DT_VCENTER | DT_WORD_ELLIPSIS | DT_NOPREFIX | DT_NOCLIP | static_cast<UINT>( align ) ) );
 				
 				//shut analyze up!
 				sizeNeeded = 0;
@@ -1282,7 +1282,7 @@ private:
 			return;
 			//abort( );
 			}
-		::DrawTextW( hDC, buffer.get( ), static_cast<int>( chars_written ), &rcText, DT_SINGLELINE | DT_VCENTER | DT_WORD_ELLIPSIS | DT_NOPREFIX | DT_NOCLIP | static_cast< UINT >( align ) );
+		VERIFY( ::DrawTextW( hDC, buffer.get( ), static_cast<int>( chars_written ), &rcText, DT_SINGLELINE | DT_VCENTER | DT_WORD_ELLIPSIS | DT_NOPREFIX | DT_NOCLIP | static_cast< UINT >( align ) ) );
 		}
 
 protected:
@@ -1355,7 +1355,7 @@ private:
 		*/
 		CSelectObject sofont( hDC, CWnd::GetFont( )->m_hObject );
 		const auto align = IsColumnRightAligned( subitem, thisHeaderCtrl ) ? DT_RIGHT : DT_LEFT;
-		::DrawTextW( hDC, buffer.get( ), static_cast<int>( chars_written_2 ), &rc, DT_SINGLELINE | DT_VCENTER | DT_CALCRECT | DT_NOPREFIX | DT_NOCLIP | static_cast<UINT>( align ) );
+		VERIFY( ::DrawTextW( hDC, buffer.get( ), static_cast<int>( chars_written_2 ), &rc, DT_SINGLELINE | DT_VCENTER | DT_CALCRECT | DT_NOPREFIX | DT_NOCLIP | static_cast<UINT>( align ) ) );
 
 		VERIFY( ::InflateRect( &rc, TEXT_X_MARGIN, 0 ) );
 		//rc.InflateRect( TEXT_X_MARGIN, 0 );
@@ -1379,7 +1379,7 @@ private:
 		*/
 		CSelectObject sofont( hDC, CWnd::GetFont( )->m_hObject );
 		const auto align = IsColumnRightAligned( subitem, thisHeaderCtrl ) ? DT_RIGHT : DT_LEFT;
-		::DrawTextW( hDC, item->m_name, static_cast<int>( item->m_name_length ), &rc, DT_SINGLELINE | DT_VCENTER | DT_CALCRECT | DT_NOPREFIX | DT_NOCLIP | static_cast<UINT>( align ) );
+		VERIFY( ::DrawTextW( hDC, item->m_name, static_cast<int>( item->m_name_length ), &rc, DT_SINGLELINE | DT_VCENTER | DT_CALCRECT | DT_NOPREFIX | DT_NOCLIP | static_cast<UINT>( align ) ) );
 			
 		VERIFY( ::InflateRect( &rc, TEXT_X_MARGIN, 0 ) );
 		//rc.InflateRect( TEXT_X_MARGIN, 0 );
@@ -1416,7 +1416,7 @@ private:
 		*/
 		CSelectObject sofont( hDC, CWnd::GetFont( )->m_hObject );
 		const auto align = IsColumnRightAligned( subitem, thisHeaderCtrl ) ? DT_RIGHT : DT_LEFT;
-		::DrawTextW( hDC, psz_subitem_formatted_text, static_cast<int>( chars_written ), &rc, DT_SINGLELINE | DT_VCENTER | DT_CALCRECT | DT_NOPREFIX | DT_NOCLIP | static_cast<UINT>( align ) );
+		VERIFY( ::DrawTextW( hDC, psz_subitem_formatted_text, static_cast<int>( chars_written ), &rc, DT_SINGLELINE | DT_VCENTER | DT_CALCRECT | DT_NOPREFIX | DT_NOCLIP | static_cast<UINT>( align ) ) );
 
 		VERIFY( ::InflateRect( &rc, TEXT_X_MARGIN, 0 ) );
 		//rc.InflateRect( TEXT_X_MARGIN, 0 );

--- a/WinDirStat/windirstat/ownerdrawnlistcontrol.h
+++ b/WinDirStat/windirstat/ownerdrawnlistcontrol.h
@@ -452,6 +452,10 @@ namespace {
 	_Pre_satisfies_( !SUCCEEDED( fmt_res ) )
 	void handle_formatting_error_COwnerDrawnListCtrl_SortItems( _In_ const HRESULT fmt_res ) {
 		displayWindowsMsgBoxWithMessage( L"Error in COwnerDrawnListCtrl::SortItems - StringCchPrintfW failed!(aborting)" );
+		//TODO:use
+		//WDS_ASSERT_EXPECTED_STRING_FORMAT_FAILURE_HRESULT( fmt_res );
+		//WDS_STRSAFE_E_INVALID_PARAMETER_HANDLER( fmt_res, "StringCchPrintfW" );
+
 		if ( fmt_res == STRSAFE_E_END_OF_FILE ) {
 			displayWindowsMsgBoxWithMessage( L"Error in COwnerDrawnListCtrl::SortItems - StringCchPrintfW failed, STRSAFE_E_END_OF_FILE! This is an error that makes no sense.(aborting)" );
 			std::terminate( );

--- a/WinDirStat/windirstat/ownerdrawnlistcontrol.h
+++ b/WinDirStat/windirstat/ownerdrawnlistcontrol.h
@@ -510,7 +510,6 @@ namespace {
 		static_assert( std::is_convertible< INT, std::underlying_type<column::ENUM_COL>::type>::value, "" );
 		for ( size_t i = 0; i < thisLoopSize; ++i ) {
 			//iterate over columns, properly populate fields.
-			ASSERT( order[ i ] == static_cast<INT>( i ) );
 			subitems_temp[ i ] = static_cast<column::ENUM_COL>( order[ i ] );
 			}
 		}
@@ -709,10 +708,6 @@ protected:
 
 		VERIFY( thisHeaderCtrl->GetOrderArray( order_temp, resize_size )) ;
 
-		for ( rsize_t i = 0; i < static_cast<rsize_t>( resize_size - 1 ); ++i ) {
-			ASSERT( static_cast< INT >( i ) == order_temp[ i ] );
-			}
-
 		const rsize_t thisLoopSize = static_cast<rsize_t>( resize_size );
 		if ( is_right_aligned_cache.empty( ) ) {
 			repopulate_right_aligned_cache( is_right_aligned_cache, thisLoopSize, thisHeaderCtrl, this );
@@ -798,7 +793,18 @@ public:
 			std::terminate( );
 			}
 
-		CPersistence::GetColumnOrder( m_persistent_name, col_order_array, itemCount );
+		std::wstring column_order_default;
+
+		for ( size_t i = 0; i < itemCount; i++ ) {
+			column_order_default += std::to_wstring( i );
+			column_order_default += L",";
+			}
+
+		ASSERT( column_order_default.back( ) == L',' );
+		column_order_default.pop_back( );
+		ASSERT( column_order_default.back( ) != L',' );
+		
+		CPersistence::GetColumnOrder( m_persistent_name, col_order_array, itemCount, column_order_default.c_str( ) );
 
 		const auto res2 = CListCtrl::SetColumnOrderArray( static_cast<int>( itemCount ), col_order_array );
 		if ( res2 == 0 ) {
@@ -809,7 +815,18 @@ public:
 		for ( size_t i = 0; i < itemCount; i++ ) {
 			col_order_array[ i ] = CListCtrl::GetColumnWidth( static_cast<int>( i ) );
 			}
-		CPersistence::GetColumnWidths( m_persistent_name, col_order_array, itemCount );
+		std::wstring column_widths_default;
+
+		for ( size_t i = 0; i < itemCount; i++ ) {
+			column_widths_default += std::to_wstring( col_order_array[ i ] );
+			column_widths_default += L",";
+			}
+
+		ASSERT( column_widths_default.back( ) == L',' );
+		column_widths_default.pop_back( );
+		ASSERT( column_widths_default.back( ) != L',' );
+
+		CPersistence::GetColumnWidths( m_persistent_name, col_order_array, itemCount, column_widths_default.c_str( ) );
 
 		for ( size_t i = 0; i < itemCount; i++ ) {
 			// To avoid "insane" settings we set the column width to maximal twice the default width.

--- a/WinDirStat/windirstat/ownerdrawnlistcontrol.h
+++ b/WinDirStat/windirstat/ownerdrawnlistcontrol.h
@@ -404,7 +404,7 @@ protected:
 		// Fill the selection rectangle background (usually dark blue)
 		//pdc.FillSolidRect( &selection, list_highlight_color );
 		::SetBkColor( hDC, list_highlight_color );
-		::ExtTextOut( hDC, 0, 0, ETO_OPAQUE, &selection, NULL, 0, NULL );
+		VERIFY( ::ExtTextOut( hDC, 0, 0, ETO_OPAQUE, &selection, NULL, 0, NULL ) );
 
 		}
 
@@ -686,7 +686,7 @@ protected:
 		*/
 		//dcmem.FillSolidRect( &rect_to_fill_solidly, GetItemBackgroundColor( pdis->itemID ) ); //NOT vectorized!
 		::SetBkColor( dcmem.m_hDC, GetItemBackgroundColor( pdis->itemID ) );
-		::ExtTextOut( dcmem.m_hDC, 0, 0, ETO_OPAQUE, &rect_to_fill_solidly, NULL, 0, NULL );
+		VERIFY( ::ExtTextOut( dcmem.m_hDC, 0, 0, ETO_OPAQUE, &rect_to_fill_solidly, NULL, 0, NULL ) );
 
 		const bool drawFocus = ( pdis->itemState bitand ODS_FOCUS ) != 0 && HasFocus( ) && bIsFullRowSelection; //partially vectorized
 

--- a/WinDirStat/windirstat/ownerdrawnlistcontrol.h
+++ b/WinDirStat/windirstat/ownerdrawnlistcontrol.h
@@ -915,7 +915,7 @@ public:
 		fi.flags  = LVFI_PARAM;
 		fi.lParam = reinterpret_cast<LPARAM>( item );
 
-		const auto i = static_cast<INT>( FindItem( &fi ) );
+		const auto i = static_cast<INT>( CListCtrl::FindItem( &fi ) );
 
 		return i;
 		}

--- a/WinDirStat/windirstat/ownerdrawnlistcontrol.h
+++ b/WinDirStat/windirstat/ownerdrawnlistcontrol.h
@@ -389,21 +389,16 @@ protected:
 			selection.right = rc.right;
 			}
 
-
-		/*
-		void CDC::FillSolidRect(LPCRECT lpRect, COLORREF clr)
-		{
-			ENSURE_VALID(this);
-			ENSURE(m_hDC != NULL);
-			ENSURE(lpRect);
-
-			::SetBkColor(m_hDC, clr);
-			::ExtTextOut(m_hDC, 0, 0, ETO_OPAQUE, lpRect, NULL, 0, NULL);
-		}
-		*/
 		// Fill the selection rectangle background (usually dark blue)
 		//pdc.FillSolidRect( &selection, list_highlight_color );
-		::SetBkColor( hDC, list_highlight_color );
+
+		//SetBkColor function: https://msdn.microsoft.com/en-us/library/dd162964.aspx
+		//If the function succeeds, the return value specifies the previous background color as a COLORREF value.
+		//If the function fails, the return value is CLR_INVALID.
+		const COLORREF result = ::SetBkColor( hDC, list_highlight_color );
+		if ( result == CLR_INVALID ) {
+			std::terminate( );
+			}
 		VERIFY( ::ExtTextOut( hDC, 0, 0, ETO_OPAQUE, &selection, NULL, 0, NULL ) );
 
 		}
@@ -672,20 +667,15 @@ protected:
 		VERIFY( ::OffsetRect( &rect_to_fill_solidly, -( point_to_offset_by.x ), -( point_to_offset_by.y ) ) );
 		
 		//ASSERT( ( rcItem - rcItem.TopLeft( ) ) == rect_to_fill_solidly );
-
-		/*
-		void CDC::FillSolidRect(LPCRECT lpRect, COLORREF clr)
-		{
-			ENSURE_VALID(this);
-			ENSURE(m_hDC != NULL);
-			ENSURE(lpRect);
-
-			::SetBkColor(m_hDC, clr);
-			::ExtTextOut(m_hDC, 0, 0, ETO_OPAQUE, lpRect, NULL, 0, NULL);
-		}
-		*/
 		//dcmem.FillSolidRect( &rect_to_fill_solidly, GetItemBackgroundColor( pdis->itemID ) ); //NOT vectorized!
-		::SetBkColor( dcmem.m_hDC, GetItemBackgroundColor( pdis->itemID ) );
+
+		//SetBkColor function: https://msdn.microsoft.com/en-us/library/dd162964.aspx
+		//If the function succeeds, the return value specifies the previous background color as a COLORREF value.
+		//If the function fails, the return value is CLR_INVALID.
+		const COLORREF set_bk_result = ::SetBkColor( dcmem.m_hDC, GetItemBackgroundColor( pdis->itemID ) );
+		if ( set_bk_result == CLR_INVALID ) {
+			std::terminate( );
+			}
 		VERIFY( ::ExtTextOut( dcmem.m_hDC, 0, 0, ETO_OPAQUE, &rect_to_fill_solidly, NULL, 0, NULL ) );
 
 		const bool drawFocus = ( pdis->itemState bitand ODS_FOCUS ) != 0 && HasFocus( ) && bIsFullRowSelection; //partially vectorized
@@ -834,7 +824,7 @@ public:
 		
 	#pragma push_macro("min")
 	#undef min
-			const auto w = std::min( col_order_array[ i ], maxWidth );
+			const auto w =	( col_order_array[ i ], maxWidth );
 	#pragma pop_macro("min")
 
 			VERIFY( CListCtrl::SetColumnWidth( static_cast<int>( i ), w ) );

--- a/WinDirStat/windirstat/treemap.cpp
+++ b/WinDirStat/windirstat/treemap.cpp
@@ -1429,7 +1429,7 @@ void CTreemap::DrawSolidRect( _In_ HDC hDC, _In_ const RECT& rc, _In_ const COLO
 	}
 	*/
 	::SetBkColor( hDC, RGB( red, green, blue ) );
-	::ExtTextOut( hDC, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL );
+	VERIFY( ::ExtTextOut( hDC, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL ) );
 	//pdc.FillSolidRect( &rc, RGB( red, green, blue ) );
 	}
 
@@ -1682,6 +1682,13 @@ void CTreemap::SetPixels( _In_ HDC offscreen_buffer, _In_reads_( maxIndex ) _Pre
 		abort( );
 		}
 
+	auto guard = WDS_SCOPEGUARD_INSTANCE( [&] {
+		const BOOL deleted = ::DeleteDC( hTempDeviceContextMemory );
+		if ( deleted == 0 ) {
+			std::terminate( );
+			}
+		} );
+
 	//VERIFY( tempDCmem.CreateCompatibleDC( &offscreen_buffer ) );
 	CBitmap bmp;
 	
@@ -1713,7 +1720,6 @@ void CTreemap::SetPixels( _In_ HDC offscreen_buffer, _In_reads_( maxIndex ) _Pre
 	//tempDCmem.SelectObject( &bmp );
 	::SelectObject( hTempDeviceContextMemory, bmp.m_hObject );
 	if ( ( rcWidth == 0 ) || ( rcHeight == 0 ) ) {
-		::DeleteDC( hTempDeviceContextMemory );
 		return;
 		}
 
@@ -1732,7 +1738,6 @@ void CTreemap::SetPixels( _In_ HDC offscreen_buffer, _In_reads_( maxIndex ) _Pre
 		displayWindowsMsgBoxWithMessage( L"offscreen_buffer.TransparentBlt failed!!! AHHH!!!!" );
 		std::terminate( );
 		}
-	::DeleteDC( hTempDeviceContextMemory );
 	}
 
 

--- a/WinDirStat/windirstat/treemap.cpp
+++ b/WinDirStat/windirstat/treemap.cpp
@@ -1416,19 +1416,13 @@ void CTreemap::DrawSolidRect( _In_ HDC hDC, _In_ const RECT& rc, _In_ const COLO
 
 	NormalizeColor( red, green, blue );
 
-
-	/*
-	void CDC::FillSolidRect(LPCRECT lpRect, COLORREF clr)
-	{
-		ENSURE_VALID(this);
-		ENSURE(m_hDC != NULL);
-		ENSURE(lpRect);
-
-		::SetBkColor(m_hDC, clr);
-		::ExtTextOut(m_hDC, 0, 0, ETO_OPAQUE, lpRect, NULL, 0, NULL);
-	}
-	*/
-	::SetBkColor( hDC, RGB( red, green, blue ) );
+	//SetBkColor function: https://msdn.microsoft.com/en-us/library/dd162964.aspx
+	//If the function succeeds, the return value specifies the previous background color as a COLORREF value.
+	//If the function fails, the return value is CLR_INVALID.
+	const COLORREF result = ::SetBkColor( hDC, RGB( red, green, blue ) );
+	if ( result == CLR_INVALID ) {
+		std::terminate( );
+		}
 	VERIFY( ::ExtTextOut( hDC, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL ) );
 	//pdc.FillSolidRect( &rc, RGB( red, green, blue ) );
 	}

--- a/WinDirStat/windirstat/treemap.cpp
+++ b/WinDirStat/windirstat/treemap.cpp
@@ -209,7 +209,7 @@ namespace {
 		//return fBegin;
 		}
 
-	inline const int if_last_child_end_scope_holder( _In_ const size_t i, _In_ const bool horizontal, _In_ const RECT remaining, _In_ const int heightOfNewRow, _Inout_ int& end_scope_holder, _In_ const bool lastChild, _In_ const std::vector<CTreeListItem*>& parent_vector_of_children ) {
+	inline const int if_last_child_end_scope_holder( _In_ const size_t i, _In_ const bool horizontal, _In_ const RECT remaining, _In_ const int heightOfNewRow, _Inout_ int& end_scope_holder, _In_ const bool lastChild, _In_ const std::vector<const CTreeListItem*>& parent_vector_of_children ) {
 		if ( lastChild ) {
 #ifdef GRAPH_LAYOUT_DEBUG
 			if ( ( i + 1 ) < rowEnd ) {
@@ -244,11 +244,11 @@ namespace {
 		}
 
 	//passing by reference: `cmp    r14, QWORD PTR [r12]` for `if ( ( i + 1 ) < rowEnd )`,
-	inline const std::uint64_t if_i_plus_one_less_than_rowEnd( _In_ const size_t rowEnd, _In_ const size_t i, _Inout_ std::map<std::uint64_t, std::uint64_t>& sizes, _In_ const std::vector<CTreeListItem*>& parent_vector_of_children ) {
+	inline const std::uint64_t if_i_plus_one_less_than_rowEnd( _In_ const size_t rowEnd, _In_ const size_t i, _Inout_ std::map<std::uint64_t, std::uint64_t>& sizes, _In_ const std::vector<const CTreeListItem*>& parent_vector_of_children ) {
 		if ( ( i + 1 ) >= rowEnd ) {
 			return 0;
 			}
-		const auto childAtIPlusOne = static_cast< CTreeListItem* >( parent_vector_of_children[ i + 1 ] );
+		const auto childAtIPlusOne = static_cast< const CTreeListItem* >( parent_vector_of_children[ i + 1 ] );
 		if ( childAtIPlusOne == NULL ) {
 			return 0;
 			}
@@ -298,7 +298,7 @@ namespace {
 		return widthOfRow;
 		}
 
-	inline const std::uint64_t max_size_of_children_in_row( _In_ const std::map<std::uint64_t, std::uint64_t>& sizes, _In_ const size_t rowBegin, _In_ const std::vector<CTreeListItem*>& vector_o_children ) {
+	inline const std::uint64_t max_size_of_children_in_row( _In_ const std::map<std::uint64_t, std::uint64_t>& sizes, _In_ const size_t rowBegin, _In_ const std::vector<const CTreeListItem*>& vector_o_children ) {
 #ifdef GRAPH_LAYOUT_DEBUG
 		TRACE( _T( "sizes[ rowBegin ]: %llu\r\n" ), sizes.at( rowBegin ) );
 		TRACE( _T( "maximumSizeOfChildrenInRow: %llu\r\n" ), maximumSizeOfChildrenInRow );
@@ -559,9 +559,9 @@ namespace {
 		}
 
 
-	void i_less_than_children_per_row( _In_ const size_t i, _In_ const std::vector<size_t>& childrenPerRow, _In_ _In_range_( 0, SIZE_T_MAX ) const size_t row, _In_ const std::vector<CTreeListItem*>& parent_vector_of_children, _In_ const size_t c ) {
+	void i_less_than_children_per_row( _In_ const size_t i, _In_ const std::vector<size_t>& childrenPerRow, _In_ _In_range_( 0, SIZE_T_MAX ) const size_t row, _In_ const std::vector<const CTreeListItem*>& parent_vector_of_children, _In_ const size_t c ) {
 		if ( i < childrenPerRow[ row ] ) {
-			const auto childAtC = static_cast< CTreeListItem* >( parent_vector_of_children.at( c ) );
+			const auto childAtC = static_cast< const CTreeListItem* >( parent_vector_of_children.at( c ) );
 			if ( childAtC != NULL ) {
 				childAtC->TmiSetRectangle( CRect( -1, -1, -1, -1 ) );
 				}
@@ -664,10 +664,10 @@ void CTreemap::RecurseCheckTree( _In_ const CTreeListItem* const item ) const {
 		}
 
 	WDS_validateRectangle_DEBUG( item, item->TmiGetRectangle( ) );
-	const auto item_vector_of_children = item->size_sorted_vector_of_children( );
+	const std::vector<const CTreeListItem*> item_vector_of_children = item->size_sorted_vector_of_children( );
 	//ASSERT( item->m_childCount == item->m_child_info->m_childCount );
 	for ( size_t i = 0; i < item->m_child_info.m_child_info_ptr->m_childCount; i++ ) {
-		const auto child = static_cast< CTreeListItem* >( item_vector_of_children.at( i ) );
+		const auto child = static_cast< const CTreeListItem* >( item_vector_of_children.at( i ) );
 		WDS_validateRectangle_DEBUG( child, item->TmiGetRectangle( ) );
 		RecurseCheckTree( child );
 		}
@@ -792,10 +792,10 @@ _Success_( return != NULL ) _Ret_maybenull_ _Must_inspect_result_ CTreeListItem*
 	//ASSERT( item->m_childCount == item->m_child_info->m_childCount );
 	const auto countOfChildren = item->m_child_info.m_child_info_ptr->m_childCount;
 
-	const auto item_vector_of_children = item->size_sorted_vector_of_children( );
+	const std::vector<const CTreeListItem*> item_vector_of_children = item->size_sorted_vector_of_children( );
 	
 	for ( size_t i = 0; i < countOfChildren; i++ ) {
-		const auto child = static_cast< CTreeListItem* >( item_vector_of_children.at( i ) );
+		const auto child = static_cast< const CTreeListItem* >( item_vector_of_children.at( i ) );
 		ASSERT( item->m_child_info.m_child_info_ptr != nullptr );
 		ASSERT( item->m_child_info.m_child_info_ptr->m_children != nullptr );
 		ASSERT( child != NULL );
@@ -949,7 +949,7 @@ bool CTreemap::KDS_PlaceChildren( _In_ const CTreeListItem* const parent, _Inout
 	return horizontalRows;
 	}
 
-void CTreemap::KDS_DrawSingleRow( _In_ const std::vector<size_t>& childrenPerRow, _In_ _In_range_( 0, SIZE_T_MAX ) const size_t& row, _In_ const std::vector<CTreeListItem*>& parent_vector_of_children, _Inout_ _In_range_( 0, SIZE_T_MAX ) size_t& c, _In_ const std::vector<double>& childWidth, _In_ const int& width, _In_ const bool& horizontalRows, _In_ const int& bottom, _In_ const double& top, _In_ const RECT& rc, _In_ CDC& pdc, _In_ const DOUBLE( &surface )[ 4 ], _In_ const DOUBLE& h, _In_ const CTreeListItem* const parent ) const {
+void CTreemap::KDS_DrawSingleRow( _In_ const std::vector<size_t>& childrenPerRow, _In_ _In_range_( 0, SIZE_T_MAX ) const size_t& row, _In_ const std::vector<const CTreeListItem*>& parent_vector_of_children, _Inout_ _In_range_( 0, SIZE_T_MAX ) size_t& c, _In_ const std::vector<double>& childWidth, _In_ const int& width, _In_ const bool& horizontalRows, _In_ const int& bottom, _In_ const double& top, _In_ const RECT& rc, _In_ CDC& pdc, _In_ const DOUBLE( &surface )[ 4 ], _In_ const DOUBLE& h, _In_ const CTreeListItem* const parent ) const {
 #ifndef DEBUG
 	UNREFERENCED_PARAMETER( parent );
 #endif
@@ -957,7 +957,7 @@ void CTreemap::KDS_DrawSingleRow( _In_ const std::vector<size_t>& childrenPerRow
 
 	for ( size_t i = 0; i < childrenPerRow[ row ]; i++, c++ ) {
 
-		const auto child = static_cast< CTreeListItem* >( parent_vector_of_children.at( c ) );
+		const auto child = static_cast< const CTreeListItem* >( parent_vector_of_children.at( c ) );
 
 		ASSERT( childWidth[ c ] >= 0 );
 		ASSERT( left > -2 );
@@ -1017,7 +1017,7 @@ void CTreemap::KDS_DrawChildren( _In_ CDC& pdc, _In_ const CTreeListItem* const 
 	const auto height = static_cast< size_t >( height_scope_holder );
 	size_t c = 0;
 	double top = horizontalRows ? rc.top : rc.left;
-	const auto parent_vector_of_children = parent->size_sorted_vector_of_children( );
+	const std::vector<const CTreeListItem*> parent_vector_of_children = parent->size_sorted_vector_of_children( );
 	const auto rows_size = rows.size( );
 	for ( size_t row = 0; row < rows_size; row++ ) {
 
@@ -1052,7 +1052,7 @@ DOUBLE CTreemap::KDS_CalcNextRow( _In_ const CTreeListItem* const parent, _In_ _
 
 	std::vector<std::uint64_t> parentSizes( parent->m_child_info.m_child_info_ptr->m_childCount, UINT64_MAX );
 
-	const auto parent_vector_of_children = parent->size_sorted_vector_of_children( );
+	const std::vector<const CTreeListItem*> parent_vector_of_children = parent->size_sorted_vector_of_children( );
 
 
 	ASSERT( parent->m_child_info.m_child_info_ptr != nullptr );
@@ -1062,7 +1062,7 @@ DOUBLE CTreemap::KDS_CalcNextRow( _In_ const CTreeListItem* const parent, _In_ _
 	ASSERT( nextChild < parent->m_child_info.m_child_info_ptr->m_childCount );//the following loop NEEDS to iterate at least once
 	for ( i = nextChild; i < parent->m_child_info.m_child_info_ptr->m_childCount; i++ ) {
 
-		const std::uint64_t childSize = static_cast< CTreeListItem* >( parent_vector_of_children.at( i ) )->size_recurse( );
+		const std::uint64_t childSize = static_cast< const CTreeListItem* >( parent_vector_of_children.at( i ) )->size_recurse( );
 		parentSizes.at( i ) = childSize;
 		if ( childSize == 0 ) {
 			ASSERT( i > nextChild );  // first child has size > 0
@@ -1100,7 +1100,7 @@ DOUBLE CTreemap::KDS_CalcNextRow( _In_ const CTreeListItem* const parent, _In_ _
 
 	// We add the rest of the children, if their size is 0.
 //#pragma warning(suppress: 6011)//not null here!
-	while ( ( i < parent->m_child_info.m_child_info_ptr->m_childCount ) && ( static_cast< CTreeListItem* >( parent_vector_of_children.at( i ) )->size_recurse( ) == 0 ) ) {
+	while ( ( i < parent->m_child_info.m_child_info_ptr->m_childCount ) && ( static_cast< const CTreeListItem* >( parent_vector_of_children.at( i ) )->size_recurse( ) == 0 ) ) {
 		i++;
 		}
 
@@ -1112,7 +1112,7 @@ DOUBLE CTreemap::KDS_CalcNextRow( _In_ const CTreeListItem* const parent, _In_ _
 		// Rectangle(1.0 * 1.0) = mySize
 		const double rowSize = mySize * rowHeight;
 		double childSize = DBL_MAX;
-		const auto thisChild = static_cast< CTreeListItem* >( parent_vector_of_children.at( nextChild + i ) );
+		const auto thisChild = static_cast< const CTreeListItem* >( parent_vector_of_children.at( nextChild + i ) );
 		if ( parentSizes.at( nextChild + i ) != UINT64_MAX ) {
 			childSize = ( double ) parentSizes.at( nextChild + i );
 			}
@@ -1137,7 +1137,7 @@ DOUBLE CTreemap::KDS_CalcNextRow( _In_ const CTreeListItem* const parent, _In_ _
 	}
 
 //if we pass horizontal by reference, compiler produces `cmp    BYTE PTR [r15], 0` for `if ( horizontal )`, pass by value generates `test    r15b, r15b`
-void CTreemap::SQV_put_children_into_their_places( _In_ const size_t& rowBegin, _In_ const size_t& rowEnd, _In_ const std::vector<CTreeListItem*>& parent_vector_of_children, _Inout_ std::map<std::uint64_t, std::uint64_t>& sizes, _In_ const std::uint64_t& sumOfSizesOfChildrenInRow, _In_ const int& heightOfNewRow, _In_ const bool horizontal, _In_ const RECT& remaining, _In_ CDC& pdc, _In_ const DOUBLE( &surface )[ 4 ], _In_ const DOUBLE& scaleFactor, _In_ const DOUBLE h, _In_ const int& widthOfRow ) const {
+void CTreemap::SQV_put_children_into_their_places( _In_ const size_t& rowBegin, _In_ const size_t& rowEnd, _In_ const std::vector<const CTreeListItem*>& parent_vector_of_children, _Inout_ std::map<std::uint64_t, std::uint64_t>& sizes, _In_ const std::uint64_t& sumOfSizesOfChildrenInRow, _In_ const int& heightOfNewRow, _In_ const bool horizontal, _In_ const RECT& remaining, _In_ CDC& pdc, _In_ const DOUBLE( &surface )[ 4 ], _In_ const DOUBLE& scaleFactor, _In_ const DOUBLE h, _In_ const int& widthOfRow ) const {
 
 	// Build the rectangles of children.
 	RECT rc;
@@ -1145,7 +1145,7 @@ void CTreemap::SQV_put_children_into_their_places( _In_ const size_t& rowBegin, 
 	
 	for ( auto i = rowBegin; i < rowEnd; i++ ) {
 		const int begin = ( int ) fBegin;
-		const auto child_at_I = static_cast< CTreeListItem* >( parent_vector_of_children[ i ] );
+		const auto child_at_I = static_cast< const CTreeListItem* >( parent_vector_of_children[ i ] );
 
 		const double fraction = child_at_i_fraction( sizes, i, sumOfSizesOfChildrenInRow, child_at_I );
 
@@ -1220,7 +1220,7 @@ void CTreemap::SQV_DrawChildren( _In_ CDC& pdc, _In_ const CTreeListItem* const 
 	// First child for next row
 	size_t head = 0;
 
-	const auto parent_vector_of_children = parent->size_sorted_vector_of_children( );
+	const std::vector<const CTreeListItem*> parent_vector_of_children = parent->size_sorted_vector_of_children( );
 
 #ifdef GRAPH_LAYOUT_DEBUG
 	TRACE( _T( "head: %llu\r\n" ), head );
@@ -1333,7 +1333,7 @@ void CTreemap::SQV_DrawChildren( _In_ CDC& pdc, _In_ const CTreeListItem* const 
 			//ASSERT( parent->m_childCount == parent->m_child_info->m_childCount );
 
 			if ( head < parent->m_child_info.m_child_info_ptr->m_childCount ) {
-				static_cast< CTreeListItem* >( parent_vector_of_children.at( head ) )->TmiSetRectangle( CRect( -1, -1, -1, -1 ) );
+				static_cast< const CTreeListItem* >( parent_vector_of_children.at( head ) )->TmiSetRectangle( CRect( -1, -1, -1, -1 ) );
 				}
 			break;
 			}

--- a/WinDirStat/windirstat/treemap.h
+++ b/WinDirStat/windirstat/treemap.h
@@ -75,21 +75,21 @@ public:
 
 	void DrawTreemap               ( _In_ CDC& offscreen_buffer, _Inout_    RECT& rc, _In_ const CTreeListItem* const root,  _In_ const Treemap_Options& options );
 
-	void DrawColorPreview          ( _In_ CDC& pdc, _In_ const RECT rc, _In_ const COLORREF           color, _In_     const Treemap_Options* const options = NULL );
+	void DrawColorPreview          ( _In_ HDC hDC, _In_ const RECT rc, _In_ const COLORREF           color, _In_     const Treemap_Options* const options = NULL );
 
 	_Success_( return != NULL ) _Ret_maybenull_ _Must_inspect_result_ CTreeListItem* FindItemByPoint( _In_ const CTreeListItem* const root, _In_ const POINT point, _In_opt_ CDirstatDoc* test_doc ) const;
 
 
 protected:
 
-	void SetPixels        ( _In_ CDC& offscreen_buffer, _In_reads_( maxIndex ) _Pre_readable_size_( maxIndex ) const COLORREF* const pixles, _In_ const int&   yStart, _In_ const int& xStart, _In_ const int& yEnd, _In_ const int& xEnd,   _In_ const int rcWidth, _In_ const size_t offset, const size_t maxIndex, _In_ const int rcHeight ) const;
+	void SetPixels        ( _In_ HDC offscreen_buffer, _In_reads_( maxIndex ) _Pre_readable_size_( maxIndex ) const COLORREF* const pixles, _In_ const int&   yStart, _In_ const int& xStart, _In_ const int& yEnd, _In_ const int& xEnd,   _In_ const int rcWidth, _In_ const size_t offset, const size_t maxIndex, _In_ const int rcHeight ) const;
 
 	void RecurseDrawGraph ( _In_ CDC& offscreen_buffer, _In_ const CTreeListItem* const     item,   _In_ const RECT& rc,     _In_ const bool asroot, _In_ const DOUBLE ( &psurface )[ 4 ], _In_ const DOUBLE h ) const;
 
 	void RecurseDrawGraph_CushionShading( _In_ const bool asroot, _Out_ DOUBLE ( &surface )[ 4 ], _In_ const DOUBLE ( &psurface )[ 4 ], _In_ const RECT rc, _In_ const DOUBLE height, _In_ const CTreeListItem* const item ) const;
 
-	void DrawCushion      ( _In_ CDC& offscreen_buffer, _In_ const RECT&              rc,        _In_ const DOUBLE ( &surface )[ 4 ], _In_                    const COLORREF col,       _In_ _In_range_( 0, 1 ) const DOUBLE  brightness ) const;
-	void DrawSolidRect    ( _In_ CDC& pdc, _In_ const RECT&              rc,        _In_ const COLORREF        col,            _In_ _In_range_( 0, 1 ) const DOUBLE   brightness ) const;
+	void DrawCushion      ( _In_ HDC offscreen_buffer, _In_ const RECT&              rc,        _In_ const DOUBLE ( &surface )[ 4 ], _In_                    const COLORREF col,       _In_ _In_range_( 0, 1 ) const DOUBLE  brightness ) const;
+	void DrawSolidRect    ( _In_ HDC hDC, _In_ const RECT&              rc,        _In_ const COLORREF        col,            _In_ _In_range_( 0, 1 ) const DOUBLE   brightness ) const;
 	void DrawChildren     ( _In_ CDC& pdc, _In_ const CTreeListItem*  const parent,    _In_ const DOUBLE ( &surface )[ 4 ], _In_                    const DOUBLE   h          ) const;
 	
 
@@ -106,7 +106,7 @@ protected:
 	//SQV -> SequoiaView
 	void SQV_DrawChildren  ( _In_ CDC&  pdc,                       _In_ const CTreeListItem* const parent, _In_ const DOUBLE ( &surface )[ 4 ], _In_ const DOUBLE h ) const;
 	void RenderLeaf        ( _In_ CDC&  offscreen_buffer,          _In_ const CTreeListItem* const item,   _In_ const DOUBLE ( &surface )[ 4 ]                   ) const;
-	void RenderRectangle   ( _In_ CDC&  offscreen_buffer,          _In_ const RECT&             rc,     _In_ const DOUBLE ( &surface )[ 4 ], _In_ DWORD color ) const;
+	void RenderRectangle   ( _In_ HDC  offscreen_buffer,          _In_ const RECT&             rc,     _In_ const DOUBLE ( &surface )[ 4 ], _In_ DWORD color ) const;
 
 	//if we pass horizontal by reference, compiler produces `cmp    BYTE PTR [r15], 0` for `if ( horizontal )`, pass by value generates `test    r15b, r15b`
 	void SQV_put_children_into_their_places( _In_ const size_t& rowBegin, _In_ const size_t& rowEnd, _In_ const std::vector<CTreeListItem*>& parent_vector_of_children, _Inout_ std::map<std::uint64_t, std::uint64_t>& sizes, _In_ const std::uint64_t& sumOfSizesOfChildrenInRow, _In_ const int& heightOfNewRow, _In_ const bool horizontal, _In_ const RECT& remaining, _In_ CDC& pdc, _In_ const DOUBLE( &surface )[ 4 ], _In_ const DOUBLE& scaleFactor, _In_ const DOUBLE h, _In_ const int& widthOfRow ) const;
@@ -115,9 +115,9 @@ protected:
 
 private:
 
-	void DrawCushion_with_heap( _In_ const size_t loop_rect_start_outer, _In_ const size_t loop_rect__end__outer, _In_ const size_t loop_rect_start_inner, _In_ const size_t loop_rect__end__inner, _In_ const size_t inner_stride, _In_ const size_t offset, _In_ _In_range_( 1024, SIZE_T_MAX ) const size_t vecSize, _In_ CDC& offscreen_buffer, const _In_ RECT& rc, _In_ _In_range_( 0, 1 ) const DOUBLE brightness, _In_ const size_t largestIndexWritten, _In_ const DOUBLE surface_0, _In_ const DOUBLE surface_1, _In_ const DOUBLE surface_2, _In_ const DOUBLE surface_3, _In_ const DOUBLE Is, _In_ const DOUBLE Ia, _In_ const DOUBLE colR, _In_ const DOUBLE colG, _In_ const DOUBLE colB ) const;
+	void DrawCushion_with_heap( _In_ const size_t loop_rect_start_outer, _In_ const size_t loop_rect__end__outer, _In_ const size_t loop_rect_start_inner, _In_ const size_t loop_rect__end__inner, _In_ const size_t inner_stride, _In_ const size_t offset, _In_ _In_range_( 1024, SIZE_T_MAX ) const size_t vecSize, _In_ HDC offscreen_buffer, const _In_ RECT& rc, _In_ _In_range_( 0, 1 ) const DOUBLE brightness, _In_ const size_t largestIndexWritten, _In_ const DOUBLE surface_0, _In_ const DOUBLE surface_1, _In_ const DOUBLE surface_2, _In_ const DOUBLE surface_3, _In_ const DOUBLE Is, _In_ const DOUBLE Ia, _In_ const DOUBLE colR, _In_ const DOUBLE colG, _In_ const DOUBLE colB ) const;
 
-	void DrawCushion_with_stack( _In_ const size_t loop_rect_start_outer, _In_ const size_t loop_rect__end__outer, _In_ const size_t loop_rect_start_inner, _In_ const size_t loop_rect__end__inner, _In_ const size_t inner_stride, _In_ const size_t offset, _In_ _In_range_( 1, 1024 ) const size_t vecSize, _In_ CDC& offscreen_buffer, const _In_ RECT& rc, _In_ _In_range_( 0, 1 ) const DOUBLE brightness, _In_ const size_t largestIndexWritten, _In_ const DOUBLE surface_0, _In_ const DOUBLE surface_1, _In_ const DOUBLE surface_2, _In_ const DOUBLE surface_3, _In_ const DOUBLE Is, _In_ const DOUBLE Ia, _In_ const DOUBLE colR, _In_ const DOUBLE colG, _In_ const DOUBLE colB ) const;
+	void DrawCushion_with_stack( _In_ const size_t loop_rect_start_outer, _In_ const size_t loop_rect__end__outer, _In_ const size_t loop_rect_start_inner, _In_ const size_t loop_rect__end__inner, _In_ const size_t inner_stride, _In_ const size_t offset, _In_ _In_range_( 1, 1024 ) const size_t vecSize, _In_ HDC offscreen_buffer, const _In_ RECT& rc, _In_ _In_range_( 0, 1 ) const DOUBLE brightness, _In_ const size_t largestIndexWritten, _In_ const DOUBLE surface_0, _In_ const DOUBLE surface_1, _In_ const DOUBLE surface_2, _In_ const DOUBLE surface_3, _In_ const DOUBLE Is, _In_ const DOUBLE Ia, _In_ const DOUBLE colR, _In_ const DOUBLE colG, _In_ const DOUBLE colB ) const;
 
 public:
 	

--- a/WinDirStat/windirstat/treemap.h
+++ b/WinDirStat/windirstat/treemap.h
@@ -100,7 +100,7 @@ protected:
 	bool KDS_PlaceChildren ( _In_ const CTreeListItem* const parent, _Inout_    std::vector<double>& childWidth, _Inout_ std::vector<double>& rows,            _Inout_    std::vector<size_t>& childrenPerRow ) const;
 	void KDS_DrawChildren  ( _In_ CDC&  pdc,                       _In_ const CTreeListItem* const parent,          _In_ const DOUBLE       ( &surface )[ 4 ], _In_ const DOUBLE h ) const;
 	
-	void KDS_DrawSingleRow( _In_ const std::vector<size_t>& childrenPerRow, _In_ _In_range_( 0, SIZE_T_MAX ) const size_t& row, _In_ const std::vector<CTreeListItem*>& parent_vector_of_children, _Inout_ _In_range_( 0, SIZE_T_MAX ) size_t& c, _In_ const std::vector<double>& childWidth, _In_ const int& width, _In_ const bool& horizontalRows, _In_ const int& bottom, _In_ const double& top, _In_ const RECT& rc, _In_ CDC& pdc, _In_ const DOUBLE( &surface )[ 4 ], _In_ const DOUBLE& h, _In_ const CTreeListItem* const parent ) const;
+	void KDS_DrawSingleRow( _In_ const std::vector<size_t>& childrenPerRow, _In_ _In_range_( 0, SIZE_T_MAX ) const size_t& row, _In_ const std::vector<const CTreeListItem*>& parent_vector_of_children, _Inout_ _In_range_( 0, SIZE_T_MAX ) size_t& c, _In_ const std::vector<double>& childWidth, _In_ const int& width, _In_ const bool& horizontalRows, _In_ const int& bottom, _In_ const double& top, _In_ const RECT& rc, _In_ CDC& pdc, _In_ const DOUBLE( &surface )[ 4 ], _In_ const DOUBLE& h, _In_ const CTreeListItem* const parent ) const;
 
 
 	//SQV -> SequoiaView
@@ -109,7 +109,7 @@ protected:
 	void RenderRectangle   ( _In_ HDC  offscreen_buffer,          _In_ const RECT&             rc,     _In_ const DOUBLE ( &surface )[ 4 ], _In_ DWORD color ) const;
 
 	//if we pass horizontal by reference, compiler produces `cmp    BYTE PTR [r15], 0` for `if ( horizontal )`, pass by value generates `test    r15b, r15b`
-	void SQV_put_children_into_their_places( _In_ const size_t& rowBegin, _In_ const size_t& rowEnd, _In_ const std::vector<CTreeListItem*>& parent_vector_of_children, _Inout_ std::map<std::uint64_t, std::uint64_t>& sizes, _In_ const std::uint64_t& sumOfSizesOfChildrenInRow, _In_ const int& heightOfNewRow, _In_ const bool horizontal, _In_ const RECT& remaining, _In_ CDC& pdc, _In_ const DOUBLE( &surface )[ 4 ], _In_ const DOUBLE& scaleFactor, _In_ const DOUBLE h, _In_ const int& widthOfRow ) const;
+	void SQV_put_children_into_their_places( _In_ const size_t& rowBegin, _In_ const size_t& rowEnd, _In_ const std::vector<const CTreeListItem*>& parent_vector_of_children, _Inout_ std::map<std::uint64_t, std::uint64_t>& sizes, _In_ const std::uint64_t& sumOfSizesOfChildrenInRow, _In_ const int& heightOfNewRow, _In_ const bool horizontal, _In_ const RECT& remaining, _In_ CDC& pdc, _In_ const DOUBLE( &surface )[ 4 ], _In_ const DOUBLE& scaleFactor, _In_ const DOUBLE h, _In_ const int& widthOfRow ) const;
 
 	bool IsCushionShading( ) const;
 

--- a/WinDirStat/windirstat/typeview.cpp
+++ b/WinDirStat/windirstat/typeview.cpp
@@ -49,7 +49,7 @@ CTypeView::CTypeView( ) : m_extensionListControl( this ), m_showTypes( true ) {
 
 //CTypeView::~CTypeView( ) { }
 
-bool CListItem::DrawSubitem( RANGE_ENUM_COL const column::ENUM_COL subitem, _In_ CDC& pdc, _In_ RECT rc, _In_ const UINT state, _Out_opt_ INT* const width, _Inout_ INT* const focusLeft, _In_ const COwnerDrawnListCtrl* const list ) const {
+bool CListItem::DrawSubitem( RANGE_ENUM_COL const column::ENUM_COL subitem, _In_ HDC hDC, _In_ RECT rc, _In_ const UINT state, _Out_opt_ INT* const width, _Inout_ INT* const focusLeft, _In_ const COwnerDrawnListCtrl* const list ) const {
 	//ASSERT_VALID( pdc );
 	//Why are we bothering to draw this ourselves?
 	if ( subitem == column::COL_EXTENSION ) {
@@ -64,11 +64,11 @@ bool CListItem::DrawSubitem( RANGE_ENUM_COL const column::ENUM_COL subitem, _In_
 		const bool list_is_full_row_selection = list->m_showFullRowSelection;
 		//list_has_focus, list_is_show_selection_always, list_highlight_text_color, list_highlight_color, list_is_full_row_selection
 
-		DrawLabel( pdc, rc, state, width, focusLeft, true, list_font, list_has_focus, list_is_show_selection_always, list_highlight_text_color, list_highlight_color, list_is_full_row_selection );
+		DrawLabel( hDC, rc, state, width, focusLeft, true, list_font, list_has_focus, list_is_show_selection_always, list_highlight_text_color, list_highlight_color, list_is_full_row_selection );
 		return true;
 		}
 	else if ( subitem == column::COL_COLOR ) {
-		DrawColor( pdc, rc, state, width );
+		DrawColor( hDC, rc, state, width );
 		return true;
 		}	
 	if ( width == NULL ) {
@@ -80,13 +80,13 @@ bool CListItem::DrawSubitem( RANGE_ENUM_COL const column::ENUM_COL subitem, _In_
 
 	}
 
-void CListItem::DrawColor( _In_ CDC& pdc, _In_ RECT rc, _In_ const UINT state, _Out_opt_ INT* width ) const {
+void CListItem::DrawColor( _In_ HDC hDC, _In_ RECT rc, _In_ const UINT state, _Out_opt_ INT* width ) const {
 	if ( width != NULL ) {
 		*width = 40;
 		return;
 		}
 
-	DrawSelection( pdc, rc, state, m_list->HasFocus( ), m_list->IsShowSelectionAlways( ), m_list->GetHighlightColor( ), m_list->m_showFullRowSelection );
+	DrawSelection( hDC, rc, state, m_list->HasFocus( ), m_list->IsShowSelectionAlways( ), m_list->GetHighlightColor( ), m_list->m_showFullRowSelection );
 	VERIFY( ::InflateRect( &rc, -( 2 ), -( 3 ) ) );
 
 	if ( ( rc.right <= rc.left ) || ( rc.bottom <= rc.top ) ) {
@@ -97,7 +97,7 @@ void CListItem::DrawColor( _In_ CDC& pdc, _In_ RECT rc, _In_ const UINT state, _
 #ifdef DEBUG
 	treemap.m_is_typeview = true;
 #endif
-	treemap.DrawColorPreview( pdc, rc, color, &( GetOptions( )->m_treemapOptions ) );
+	treemap.DrawColorPreview( hDC, rc, color, &( GetOptions( )->m_treemapOptions ) );
 	}
 
 _Pre_satisfies_( subitem == column::COL_BYTES ) _Success_( SUCCEEDED( return ) )

--- a/WinDirStat/windirstat/typeview.h
+++ b/WinDirStat/windirstat/typeview.h
@@ -43,7 +43,7 @@ class CListItem final : public COwnerDrawnListItem {
 		//concrete_compare is called as a single line INSIDE a single line function. Let's ask for inlining.
 		inline  INT          concrete_compare ( _In_ const CListItem* const other, RANGE_ENUM_COL const column::ENUM_COL subitem ) const;
 		virtual INT          Compare          ( _In_ const COwnerDrawnListItem* const other, RANGE_ENUM_COL const column::ENUM_COL subitem                               ) const override final;
-		virtual bool         DrawSubitem      ( RANGE_ENUM_COL const column::ENUM_COL subitem, _In_ CDC& pdc, _In_ RECT rc, _In_ const UINT state, _Out_opt_ INT* const width, _Inout_ INT* const focusLeft, _In_ const COwnerDrawnListCtrl* const list ) const override final;
+		virtual bool         DrawSubitem      ( RANGE_ENUM_COL const column::ENUM_COL subitem, _In_ HDC hDC, _In_ RECT rc, _In_ const UINT state, _Out_opt_ INT* const width, _Inout_ INT* const focusLeft, _In_ const COwnerDrawnListCtrl* const list ) const override final;
 			
 		_Must_inspect_result_ _Success_( SUCCEEDED( return ) )
 		virtual HRESULT Text_WriteToStackBuffer( RANGE_ENUM_COL const column::ENUM_COL subitem, WDS_WRITES_TO_STACK( strSize, chars_written ) PWSTR psz_text, _In_ const rsize_t strSize, _On_failure_( _Post_valid_ ) rsize_t& sizeBuffNeed, _Out_ rsize_t& chars_written ) const override final;
@@ -60,7 +60,7 @@ class CListItem final : public COwnerDrawnListItem {
 		_Pre_satisfies_( subitem == column::COL_BYTESPERCENT ) _Success_( SUCCEEDED( return ) )
 		 inline const HRESULT Text_WriteToStackBuffer_COL_BYTESPERCENT( RANGE_ENUM_COL const column::ENUM_COL subitem, WDS_WRITES_TO_STACK( strSize, chars_written ) PWSTR psz_text, _In_ const rsize_t strSize, rsize_t& sizeBuffNeed, _Out_ rsize_t& chars_written ) const;
 
-			    void         DrawColor        ( _In_ CDC& pdc, _In_ RECT rc, _In_ const UINT state, _Out_opt_ INT* const width ) const;
+			    void         DrawColor        ( _In_ HDC hDC, _In_ RECT rc, _In_ const UINT state, _Out_opt_ INT* const width ) const;
 			    DOUBLE       GetBytesFraction (                                                                                 ) const;
 	private:
 		const CExtensionListControl* m_list;

--- a/WinDirStat/windirstat/xyslider.cpp
+++ b/WinDirStat/windirstat/xyslider.cpp
@@ -189,7 +189,7 @@ void CXySlider::PaintBackground( _In_ CDC& pdc ) {
 	VERIFY( ::ExtTextOutW( pdc.m_hDC, 0, 0, ETO_OPAQUE, &rc, NULL, 0u, NULL ) );
 
 	CPen pen( PS_SOLID, 1, GetSysColor( COLOR_3DLIGHT ) );
-	CSelectObject sopen( pdc, pen );
+	CSelectObject sopen( pdc.m_hDC, pen.m_hObject );
 
 	move_to_coord( pdc, rc.left, m_zero.y );
 
@@ -246,7 +246,7 @@ void CXySlider::PaintGripper( _In_ CDC& pdc ) {
 
 
 	CPen pen( PS_SOLID, 1, ::GetSysColor( COLOR_3DSHADOW ) );
-	CSelectObject sopen( pdc, pen );
+	CSelectObject sopen( pdc.m_hDC, pen.m_hObject );
 
 	move_to_coord( pdc, rc.left, ( rc.top + ( rc.bottom - rc.top ) / 2 ) );
 
@@ -457,7 +457,7 @@ void CXySlider::OnPaint( ) {
 	VERIFY( dcmem.CreateCompatibleDC( &dc ) );
 	CBitmap bm;
 	VERIFY( bm.CreateCompatibleBitmap( &dc, w, h ) );
-	CSelectObject sobm( dcmem, bm );
+	CSelectObject sobm( dcmem.m_hDC, bm.m_hObject );
 
 	PaintBackground( dcmem );
 	// PaintValues(&dcmem); This is too noisy


### PR DESCRIPTION
This pull request ended up much larger than the branch name (`add-NTFS-special-file-support`) sounds. 

In pursuit of 100% used-space-accounting-for ([as NTFS "misreports" free space](http://blogs.msdn.com/b/ntdebugging/archive/2014/05/08/ntfs-misreports-free-space-part-3.aspx)), altWinDirStat now displays the size of the NTFS Master File Table, and I've implemented *experimental* support for displaying the sizes of other NTFS metafiles.

I've also fixed the annoying issue (#9) where running altWinDirStat for the first time - only where the vanilla version of WinDirStat has **also** not been run - would display a garbled file tree & file type list. 

That bug wasn't visible on my dev machine because I never actually deleted the registry key where settings are stored. Oliver Schneider & Bernhard Seifert included [`Delete HKCU\Software\seifert\windirstat` in the original test plan](https://github.com/ariccio/altWinDirStat/blob/master/WinDirStat/TESTPLAN.txt#L9), which I don't really use. Shame on me.

This pull request does suffer from one regression: working with very large folders (number of items) is a bit slower, sadly. I fixed an annoying bug where the last item in the list view would appear after the parent folder had been collapsed. I refer to it as a "zombie item".

As an example, here's the my [AppData folder](http://windows.microsoft.com/en-us/windows-8/what-appdata-folder), expanded:
![wds_nozombie](https://cloud.githubusercontent.com/assets/2142308/11023746/7f195118-864f-11e5-9193-e1831142b594.PNG)

Here it is, collapsed, with "zombie item":
![wds_zombie](https://cloud.githubusercontent.com/assets/2142308/11023758/ac3af0c0-864f-11e5-9f52-1dfe854b249f.PNG)


Here's the collapsed folder, without the "zombie item" (fixed):
![wds_fixedzombie](https://cloud.githubusercontent.com/assets/2142308/11023768/d86040e2-864f-11e5-8e13-76432dfa54a5.PNG)

----

Backend changes:
- I replaced many uses of [`CDC`](https://msdn.microsoft.com/en-us/library/fxhhde73.aspx) with the raw [`HDC`](https://msdn.microsoft.com/en-us/library/dd183560.aspx), which improves `const`-correctness, and allows me to check return values where `MFC` doesn't.
- I replaced some `CTreeListItem*`s with `const CTreeListItem*`s.
- Added some `TRACE`s.