### PR TITLE
Fixes #8 (sorting issue)

### DIFF
--- a/WinDirStat/windirstat/TreeListControl.cpp
+++ b/WinDirStat/windirstat/TreeListControl.cpp
@@ -1892,9 +1892,12 @@ void CTreeListControl::ExpandItem( _In_ _In_range_( 0, INT_MAX ) const int i, _I
 
 	item->SortChildren( this );
 	
+
+	TRACE( _T( "Setting redraw FALSE\r\n" ) );
 	CWnd::SetRedraw( FALSE );
 	ExpandItemInsertChildren( item, i, scroll );
 	CWnd::SetRedraw( TRUE );
+	TRACE( _T( "Setting redraw TRUE\r\n" ) );
 
 	item->SetExpanded( true );
 

--- a/WinDirStat/windirstat/datastructures.h
+++ b/WinDirStat/windirstat/datastructures.h
@@ -114,7 +114,7 @@ enum class Treemap_STYLE {
 namespace UpdateAllViews_ENUM {
 	// Hints for UpdateAllViews()
 	enum {
-		HINT_NULL,				        // General update
+		HINT_NULL,				        // General update (passed by CView::OnInitialUpdate( ))
 		HINT_NEWROOT,			        // Root item has changed - clear everything.
 		HINT_SELECTIONCHANGED,	        // The selection has changed, EnsureVisible.
 		HINT_SHOWNEWSELECTION,	        // The selection has changed, Show Path
@@ -124,6 +124,7 @@ namespace UpdateAllViews_ENUM {
 		HINT_LISTSTYLECHANGED,	        // Options: List style (grid/stripes) or treelist colors changed
 		HINT_TREEMAPSTYLECHANGED,	    // Options: Treemap style (grid, colors etc.) changed
 		};
+	static_assert( HINT_NULL == 0, "CView::OnInitialUpdate( ) passes 0, should be equal to HINT_NULL" );
 
 	}
 

--- a/WinDirStat/windirstat/directory_enumeration.h
+++ b/WinDirStat/windirstat/directory_enumeration.h
@@ -34,7 +34,7 @@ std::pair<DOUBLE, bool>    DoSomeWorkShim                ( _Inout_ CTreeListItem
 
 
 _Success_( return < UINT64_ERROR )
-const std::uint64_t get_uncompressed_file_size( const CTreeListItem* const item );
+const std::uint64_t get_uncompressed_file_size( _In_ const CTreeListItem* const item );
 
 #else
 

--- a/WinDirStat/windirstat/dirstatview.h
+++ b/WinDirStat/windirstat/dirstatview.h
@@ -67,6 +67,7 @@ protected:
 
 		CView::OnInitialUpdate( );
 		}
+	//Called by CView::OnPaint
 	virtual void OnDraw( CDC* pDC ) override final {
 		ASSERT_VALID( pDC );
 		CView::OnDraw( pDC );

--- a/WinDirStat/windirstat/dirstatview.h
+++ b/WinDirStat/windirstat/dirstatview.h
@@ -55,6 +55,16 @@ protected:
 		}
 
 	virtual void OnInitialUpdate( ) override final {
+		/*
+		void CView::OnInitialUpdate()
+		{
+			OnUpdate(NULL, 0, NULL);        // initial update
+		}
+		*/
+
+		//OnUpdate(NULL, 0, NULL) calls CGraphView::OnUpdate
+		//also CDirstatView::OnUpdate?
+
 		CView::OnInitialUpdate( );
 		}
 	virtual void OnDraw( CDC* pDC ) override final {

--- a/WinDirStat/windirstat/graphview.h
+++ b/WinDirStat/windirstat/graphview.h
@@ -123,6 +123,13 @@ protected:
 		}
 	
 	virtual void OnInitialUpdate( ) override final {
+		/*
+		void CView::OnInitialUpdate()
+		{
+			OnUpdate(NULL, 0, NULL);        // initial update
+		}
+		*/
+		//OnUpdate(NULL, 0, NULL) calls CGraphView::OnUpdate
 		CView::OnInitialUpdate( );
 		}
 	

--- a/WinDirStat/windirstat/ownerdrawnlistcontrol.h
+++ b/WinDirStat/windirstat/ownerdrawnlistcontrol.h
@@ -199,14 +199,14 @@ public:
 
 
 	INT CompareS( _In_ const COwnerDrawnListItem* const other, _In_ const SSorting& sorting ) const {
-		if ( sorting.column1 == column::COL_NAME ) {
-#pragma warning( suppress: 4711 )//C4711: function 'int __cdecl signum<int>(int)' selected for automatic inline expansion
-			const auto sort_result = signum( wcscmp( m_name, other->m_name ) );
-		
-			if ( sort_result != 0 ) {
-				return sort_result;
-				}
-			}
+//		if ( sorting.column1 == column::COL_NAME ) {
+//#pragma warning( suppress: 4711 )//C4711: function 'int __cdecl signum<int>(int)' selected for automatic inline expansion
+//			const auto sort_result = signum( wcscmp( m_name, other->m_name ) );
+//		
+//			if ( sort_result != 0 ) {
+//				return sort_result;
+//				}
+//			}
 
 		auto r_1 = compare_interface( other, sorting.column1 );
 		if ( abs( r_1 ) < 2 && !sorting.ascending1 ) {

--- a/WinDirStat/windirstat/typeview.h
+++ b/WinDirStat/windirstat/typeview.h
@@ -156,10 +156,18 @@ protected:
 	BOOL                  g_fRedrawEnabled;
 
 	virtual void OnInitialUpdate( ) override final {
+		/*
+		void CView::OnInitialUpdate()
+		{
+			OnUpdate(NULL, 0, NULL);        // initial update
+		}
+		*/
+		//OnUpdate(NULL, 0, NULL) calls CTypeView::OnUpdate
 		CView::OnInitialUpdate( );
 		}
 	virtual void OnUpdate        ( CView* pSender, LPARAM lHint, CObject* pHint ) override final;
 	
+	//Called by CView::OnPaint
 	virtual void OnDraw( CDC* pDC ) override final {
 		ASSERT_VALID( pDC );
 		CView::OnDraw( pDC );

--- a/WinDirStat/windirstat/windirstat.cpp
+++ b/WinDirStat/windirstat/windirstat.cpp
@@ -405,35 +405,9 @@ void CDirstatApp::OnFileOpen( ) {
 	if ( !( path_str.empty( ) ) ) {
 		m_pDocTemplate->OpenDocumentFile( path_str.c_str( ), true );
 		}
-	
-	//CSelectDrivesDlg dlg;
-	//if ( IDOK == dlg.DoModal( ) ) {
-	//	//ASSERT( dlg.m_folder_name_heap == dlg.m_folderName.GetString( ) );
-	//	const auto path = EncodeSelection( static_cast<RADIO>( dlg.m_radio ), dlg.m_folder_name_heap.c_str( ), dlg.m_drives );
-	//	if ( path.find( '|' ) == std::wstring::npos ) {
-	//		m_pDocTemplate->OpenDocumentFile( path.c_str( ), true );
-	//		}
-	//	}
 	}
 
 void CDirstatApp::OnFileOpenLight( ) {
-/*
-
-//	const UINT flags = ( BIF_RETURNONLYFSDIRS bitor BIF_USENEWUI bitor BIF_NONEWFOLDERBUTTON );
-//	WTL::CFolderDialog bob { NULL, global_strings::select_folder_dialog_title_text, flags };
-//	//ASSERT( m_folder_name_heap.compare( m_folderName ) == 0 );
-//	bob.SetInitialFolder( m_folder_name_heap.c_str( ) );
-//	auto resDoModal = bob.DoModal( );
-//	if ( resDoModal == IDOK ) {
-//		m_folder_name_heap = bob.GetFolderPath( );
-//		//m_folderName = m_folder_name_heap.c_str( );
-//		//ASSERT( m_folder_name_heap.compare( m_folderName ) == 0 );
-//		TRACE( _T( "User chose: %s\r\n" ), m_folder_name_heap.c_str( ) );
-//		}
-//	else {
-//		TRACE( _T( "user hit cancel - no changes necessary.\r\n" ) );
-//		}
-*/
 	const UINT flags = ( BIF_RETURNONLYFSDIRS bitor BIF_USENEWUI bitor BIF_NONEWFOLDERBUTTON );
 	WTL::CFolderDialog bob { NULL, global_strings::select_folder_dialog_title_text, flags };
 	//ASSERT( m_folder_name_heap.compare( m_folderName ) == 0 );
@@ -441,22 +415,11 @@ void CDirstatApp::OnFileOpenLight( ) {
 	if ( resDoModal == IDOK ) {
 		PCWSTR const m_folder_name_heap( bob.GetFolderPath( ) );
 		if ( wcslen( m_folder_name_heap ) > 0 ) {
+
+			//Here, calls CSingleDocTemplate::OpenDocumentFile (in docsingl.cpp)
 			m_pDocTemplate->OpenDocumentFile( m_folder_name_heap, TRUE );
 			}
 		}
-	//const auto path_str = test_file_open( );
-	//if ( !( path_str.empty( ) ) ) {
-	//	m_pDocTemplate->OpenDocumentFile( path_str.c_str( ), true );
-	//	}
-	
-	//CSelectDrivesDlg dlg;
-	//if ( IDOK == dlg.DoModal( ) ) {
-	//	//ASSERT( dlg.m_folder_name_heap == dlg.m_folderName.GetString( ) );
-	//	const auto path = EncodeSelection( static_cast<RADIO>( dlg.m_radio ), dlg.m_folder_name_heap.c_str( ), dlg.m_drives );
-	//	if ( path.find( '|' ) == std::wstring::npos ) {
-	//		m_pDocTemplate->OpenDocumentFile( path.c_str( ), true );
-	//		}
-	//	}
 	}
 
 BOOL CDirstatApp::OnIdle( _In_ LONG lCount ) {


### PR DESCRIPTION
Contrary to the name of this branch, there wasn't a blank header control bug, and thus it's not fixed.

----

This fixes issue #8, by eliminating the "special" case in CompareS.

The drive-by performance fix is that we don't try to query the
uncompressed file size of an item with children (most folders), as that
appears to always fail (with access denied).

I also refactored CTreeListItem::SetVisible.

I also added some descriptive comments.